### PR TITLE
Stops hardcoding IL as the only jurisdiction

### DIFF
--- a/docassemble/EFSPIntegration/data/questions/admin_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/admin_interview.yml
@@ -19,7 +19,10 @@ default screen parts:
 ---
 metadata:
   title: |
-    EFSP Admin Interface  
+    EFSP Admin Interface
+---
+code: |
+  proxy_conn = ProxyConnection(credentials_code_block='tyler_login', default_jurisdiction=jurisdiction_id)
 ---
 objects:
   - person_to_reg: ALIndividual
@@ -1423,8 +1426,14 @@ question: |
 subquestion: |
   ${ error_message }
 ---
-code: |
-  jurisdiction_id = 'illinois'
+id: which-jurisdiction
+question: |
+  Which jurisdiction?
+fields:
+  - no label: jurisdiction_id
+    choices:
+      - Illinois: 'illinois'
+      - Massachusetts: 'massachusetts'
 ---
 mandatory: True
 code: |

--- a/docassemble/EFSPIntegration/data/questions/any_filing_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/any_filing_interview.yml
@@ -15,8 +15,14 @@ include:
 code: |
   user_wants_efile = True # This interview is always for e-filing
 ---
-code: |
-  jurisdiction_id = 'illinois'
+id: which-jurisdiction
+question: |
+  Which jurisdiction?
+fields:
+  - no label: jurisdiction_id
+    choices:
+      - Illinois: 'illinois'
+      - Massachusetts: 'massachusetts'
 ---
 code: |
   user_registration_choices = [
@@ -428,7 +434,7 @@ id: make a filing
 question: |
   Make a Filing
 subquestion: |
-  Welcome! You can make any type of filing in an Illinois court, to a pre-existing or new case, in this interview.
+  Welcome! You can make any type of filing in an ${ jurisdiction_id.title() } court, to a pre-existing or new case, in this interview.
 continue button field: welcome
 ---
 id: return date
@@ -1114,7 +1120,4 @@ code: |
   if not needs_all_info:
     resp_data = proxy_conn.get_service_information(court_id, found_case.tracking_id).data
     attached_service_contacts = parse_service_contacts(resp_data)
----
-comment: |
-  service_information
 ---

--- a/docassemble/EFSPIntegration/data/questions/case_search.yml
+++ b/docassemble/EFSPIntegration/data/questions/case_search.yml
@@ -154,8 +154,8 @@ code: |
 ---
 event: case_search_task
 code: |
-  background_response_action('case_search_done', cms_conn_and_cases=search_case_by_name(proxy_conn=proxy_conn,
-      var_name='found_cases', court_id=court_id, somebody=somebody, filter_fn=filter_fn))
+  background_response_action('case_search_done', cms_conn_and_cases=[*search_case_by_name(proxy_conn=proxy_conn,
+      var_name='found_cases', court_id=court_id, somebody=somebody, filter_fn=filter_fn)])
 ---
 objects:
   - found_cases: DAEmpty

--- a/docassemble/EFSPIntegration/data/questions/common_qs.yml
+++ b/docassemble/EFSPIntegration/data/questions/common_qs.yml
@@ -1,8 +1,5 @@
 ---
 code: |
-  jurisdiction_id = 'illinois'
----
-code: |
   user_registration_choices = [
     ('INDIVIDUAL', 'Pro Se user'),
     ('FIRM_ADMINISTRATOR', 'Administrator of a new firm'),
@@ -49,7 +46,7 @@ fields:
   - City: person_to_reg.address.city
   - State: person_to_reg.address.state
     code: states_list()
-    default: IL
+    default: ${ state_name_to_code(jurisdiction_id) }
   - Zip: person_to_reg.address.zip
   - Country: person_to_reg.address.country
     code: countries_list()

--- a/docassemble/EFSPIntegration/data/questions/login_qs.yml
+++ b/docassemble/EFSPIntegration/data/questions/login_qs.yml
@@ -6,15 +6,12 @@ modules:
 include:
   - common_qs.yml
 ---
-code: |
-  proxy_conn = ProxyConnection(credentials_code_block='tyler_login', default_jurisdiction='illinois')
----
 id: eFile Login
 question: |
-  eFile IL Login Info
+  eFile${ state_name_to_code(jurisdiction_id) } Login Info
 subquestion: |
-  Provide your eFile Illinois Login information. If you don't yet have a login, you can create
-  <a href="${ interview_url(i="docassemble.EFSPIntegration:unauthenticated_interview.yml", reset=1) }" target="_blank">a new account here</a>.
+  Provide your eFile ${ jurisdiction_id.title() } Login information. If you don't yet have a login, you can create
+  <a href="${ interview_url(i="docassemble.EFSPIntegration:unauthenticated_interview.yml", reset=1, jurisdiction_id=jurisdiction_id) }" target="_blank">a new account here</a>.
 fields:
   - email/username: my_username
   - password: my_password

--- a/docassemble/EFSPIntegration/data/questions/unauthenticated_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/unauthenticated_interview.yml
@@ -11,6 +11,15 @@ objects:
   person_to_reg: Individual
 ---
 code: |
+  if 'jurisdiction_id' in url_args:
+    jurisdiction_id = url_args['jurisdiction_id']
+  else:
+    jurisdiction_id = 'illinois'
+---
+code: |
+  proxy_conn = ProxyConnection(credentials_code_block='tyler_login', default_jurisdiction=jurisdiction_id)
+---
+code: |
   user_admin_list = [
     ('self_resend_activation', 'Resend Self Activitation Email'),
     ('reset_user_password', 'Reset Your Password'),
@@ -23,8 +32,9 @@ code: |
   ]
 ---
 question: | 
-  What would you like to do?
+  eFile${ state_name_to_code(jurisdiction_id) } User Management
 subquestion: |
+  You aren't logged in, but you can take any of the below actions
 
   ${ action_button_html(url_ask(
       [{'recompute': ['register_introduction', 'person_to_reg', 'register', 'register_status']}]),
@@ -73,7 +83,7 @@ question: |
   % endif
 subquestion: |
   % if resp.is_ok():
-  You will get an email from eFileIl asking you to activate your account.
+  You will get an email from efile${ state_name_to_code(jurisdiction_id) } asking you to activate your account.
   
   [Resend activation email](${ url_ask([{'recompute': ['self_resend_activation','show_resp']}]) })
 
@@ -85,8 +95,10 @@ subquestion: |
 continue button field: register_status
 ---
 question: |
-  This website will help you register as an e-file user in Illinois
-continue button field: register_introduction  
+  This website will help you register as an e-filing user in ${ jurisdiction_id.title() }
+subquestion: |
+  You will need to provide your email and create a password.
+continue button field: register_introduction
 ---
 mandatory: True
 code: |

--- a/docassemble/EFSPIntegration/data/sources/admin_interview.feature
+++ b/docassemble/EFSPIntegration/data/sources/admin_interview.feature
@@ -11,6 +11,8 @@ Feature: The interviews run without erroring
   Scenario: admin_interview.yml Admin login
     Given I start the interview at "admin_interview.yml"
     And the maximum seconds for each Step in this Scenario is 15
+    And I set the variable "jurisdiction_id" to "illinois"
+    And I tap to continue
     And I set the variable "my_username" to secret "TYLER_EMAIL"
     And I set the variable "my_password" to secret "TYLER_PASSWORD"
     And I tap to continue
@@ -22,6 +24,8 @@ Feature: The interviews run without erroring
   Scenario: admin_interview.yml Pro Se login 
     Given I start the interview at "admin_interview.yml"
     And the maximum seconds for each Step in this Scenario is 20
+    And I set the variable "jurisdiction_id" to "illinois"
+    And I tap to continue
     And I set the variable "my_username" to secret "PROSE_EMAIL"
     And I set the variable "my_password" to secret "PROSE_PASSWORD"
     And I tap to continue
@@ -33,6 +37,8 @@ Feature: The interviews run without erroring
     Given I start the interview at "admin_interview.yml"
     And the maximum seconds for each Step in this Scenario is 20
     And I check all pages for accessibility issues
+    And I set the variable "jurisdiction_id" to "illinois"
+    And I tap to continue
     And I set the variable "my_username" to secret "TYLER_EMAIL"
     And I set the variable "my_password" to secret "TYLER_PASSWORD"
     And I tap to continue
@@ -49,6 +55,8 @@ Feature: The interviews run without erroring
     Given I start the interview at "admin_interview.yml"
     And the maximum seconds for each Step in this Scenario is 50
     And I check all pages for accessibility issues
+    And I set the variable "jurisdiction_id" to "illinois"
+    And I tap to continue
     And I set the variable "my_username" to secret "TYLER_EMAIL"
     And I set the variable "my_password" to secret "TYLER_PASSWORD"
     And I tap to continue
@@ -68,6 +76,8 @@ Feature: The interviews run without erroring
   Scenario: admin_interview.yml See court information
     Given I start the interview at "admin_interview.yml"
     And the maximum seconds for each Step in this Scenario is 20
+    And I set the variable "jurisdiction_id" to "illinois"
+    And I tap to continue
     And I set the variable "my_username" to secret "TYLER_EMAIL"
     And I set the variable "my_password" to secret "TYLER_PASSWORD"
     And I tap to continue
@@ -86,6 +96,8 @@ Feature: The interviews run without erroring
   Scenario: multiple-times through attach
     Given I start the interview at "admin_interview.yml"
     And the maximum seconds for each Step in this Scenario is 40
+    And I set the variable "jurisdiction_id" to "illinois"
+    And I tap to continue
     And I set the variable "my_username" to secret "TYLER_EMAIL"
     And I set the variable "my_password" to secret "TYLER_PASSWORD"
     And I tap to continue
@@ -124,6 +136,8 @@ Feature: The interviews run without erroring
   Scenario: earlyish stop attach when no service contacts
     Given I start the interview at "admin_interview.yml"
     And the maximum seconds for each Step in this Scenario is 40
+    And I set the variable "jurisdiction_id" to "illinois"
+    And I tap to continue
     And I set the variable "my_username" to secret "PROSE_EMAIL"
     And I set the variable "my_password" to secret "PROSE_PASSWORD"
     And I tap to continue

--- a/docassemble/EFSPIntegration/data/sources/any_filing_interview.feature
+++ b/docassemble/EFSPIntegration/data/sources/any_filing_interview.feature
@@ -7,6 +7,8 @@ Feature: Make any type of filing
   Scenario: any_filing_interview starts
     Given I start the interview at "any_filing_interview.yml"
     And the maximum seconds for each Step in this Scenario is 50
+    And I set the variable "jurisdiction_id" to "illinois"
+    And I tap to continue
     And I tap to continue
     And I set the variable "my_username" to secret "TYLER_EMAIL"
     And I set the variable "my_password" to secret "TYLER_PASSWORD"
@@ -52,6 +54,8 @@ Feature: Make any type of filing
   Scenario: any_filing_interview can handle a pro-se user
     Given I start the interview at "any_filing_interview.yml"
     And the maximum seconds for each Step in this Scenario is 50
+    And I set the variable "jurisdiction_id" to "illinois"
+    And I tap to continue
     And I tap to continue
     And I set the variable "my_username" to secret "PROSE_EMAIL"
     And I set the variable "my_password" to secret "PROSE_PASSWORD"
@@ -97,6 +101,8 @@ Feature: Make any type of filing
       Given I start the interview at "any_filing_interview.yml"
       And I check all pages for accessibility issues
       And the maximum seconds for each Step in this Scenario is 100
+      And I set the variable "jurisdiction_id" to "illinois"
+      And I tap to continue
       And I tap to continue
       And I set the variable "my_username" to secret "PROSE_EMAIL"
       And I set the variable "my_password" to secret "PROSE_PASSWORD"

--- a/docassemble/EFSPIntegration/efm_client.py
+++ b/docassemble/EFSPIntegration/efm_client.py
@@ -532,7 +532,7 @@ class ProxyConnection:
   #                                        data=all_vars)
   #  return self._call_proxy(send)
   
-  def calculate_filing_fees(self, court_id:str, court_bundle:ALDocumentBundle=None):
+  def calculate_filing_fees(self, court_id:str, court_bundle:ALDocumentBundle):
     all_vars = _get_all_vars(court_bundle)
     send = lambda: self.proxy_client.post(self.full_url(f'filingreview/courts/{court_id}/filing/fees'),
           data=all_vars)

--- a/docassemble/EFSPIntegration/efm_client.py
+++ b/docassemble/EFSPIntegration/efm_client.py
@@ -3,6 +3,7 @@ import re
 import json
 import logging
 import isodate
+import pycountry
 from datetime import datetime
 from typing import Optional, Union, List, Dict
 import http.client as http_client
@@ -15,9 +16,15 @@ from docassemble.AssemblyLine.al_document import ALDocumentBundle
 from docassemble.AssemblyLine.al_general import ALIndividual
 from datetime import datetime
 
-__all__ = ['ApiResponse','ProxyConnection']
+__all__ = ['ApiResponse','ProxyConnection', 'state_name_to_code']
 
-class ApiResponse(DAObject):
+def state_name_to_code(state_name:str) -> str:
+  try:
+    return pycountry.subdivisions.lookup(state_name).code.split('-')[-1]
+  except LookupError as ex:
+    return state_name
+
+class ApiResponse:
   def __init__(self, response_code: int, error_msg:Optional[str], data):
     self.response_code = response_code
     self.error_msg = error_msg
@@ -496,12 +503,12 @@ class ProxyConnection:
     send = lambda: self.proxy_client.delete(self.full_url(f'filingreview/courts/{court_id}/filings/{filing_id}'))
     return self._call_proxy(send) 
 
-  def check_filing(self, court_id:str, court_bundle:ALDocumentBundle=None):
+  def check_filing(self, court_id:str, court_bundle:ALDocumentBundle):
     all_vars = _get_all_vars(court_bundle) 
     send = lambda: self.proxy_client.get(self.full_url(f'filingreview/courts/{court_id}/filing/check'), data=all_vars)
     return self._call_proxy(send)
 
-  def file_for_review(self, court_id:str, court_bundle:ALDocumentBundle=None):
+  def file_for_review(self, court_id:str, court_bundle:ALDocumentBundle):
     all_vars = _get_all_vars(court_bundle) 
     send = lambda: self.proxy_client.post(self.full_url(f'filingreview/courts/{court_id}/filings'),
           data=all_vars)
@@ -510,8 +517,8 @@ class ProxyConnection:
   def get_service_types(self, court_id:str, court_bundle:ALDocumentBundle=None):
     """Checks the court info: if it has conditional service types, call a special API with all filing info so far to get service types"""
     court_info = self.get_court(court_id)
-    if court_info.data.get('hasconditionalservicetypes'):
-      all_vars = _get_all_vars(court_bundle) 
+    if court_info.data.get('hasconditionalservicetypes') and court_bundle:
+      all_vars = _get_all_vars(court_bundle)
       send = lambda: self.proxy_client.get(self.full_url(f'filingreview/courts/{court_id}/filing/servicetypes'),
         data=all_vars)
       return self._call_proxy(send)

--- a/mypy.ini
+++ b/mypy.ini
@@ -17,3 +17,6 @@ ignore_missing_imports = True
 
 [mypy-isodate] 
 ignore_missing_imports = True
+
+[mypy-pycountry]
+ignore_missing_imports = True


### PR DESCRIPTION
* requires us to explictily put a `proxy_conn` assignment in each interview, to
  set the default jurisdiction
* also adds a `state_name_to_code` function so we can get from 'illinois' to IL
* lets you start the "register user" interview for any jurisdiction