### PR TITLE
generic-object-ize case_search, misc

### DIFF
--- a/docassemble/EFSPIntegration/conversions.py
+++ b/docassemble/EFSPIntegration/conversions.py
@@ -49,7 +49,7 @@ def transform_json_variables(obj):
         return obj
     if isinstance(obj, dict):
         if '_class' in obj and isinstance(obj['_class'], str) and 'instanceName' in obj and isinstance(obj['instanceName'], str) \
-          and obj['_class'].startswith('docassemble.base') and not illegal_variable_name(obj['_class']):
+          and (obj['_class'].startswith('docassemble.base.') or obj['_class'].startswith('docassemble.AssemblyLine.')) and not illegal_variable_name(obj['_class']):
             the_module = re.sub(r'\.[^\.]+$', '', obj['_class'])
             try:
                 importlib.import_module(the_module)

--- a/docassemble/EFSPIntegration/conversions.py
+++ b/docassemble/EFSPIntegration/conversions.py
@@ -3,10 +3,12 @@
 import re
 from datetime import datetime, timezone
 from typing import List, Dict, Tuple, Any, Callable, Optional
-from docassemble.base.util import DAList, DAObject, DADateTime, as_datetime, validation_error, log
+from docassemble.base.util import DAList, DAObject, DADateTime, as_datetime, validation_error, log, as_datetime
 from docassemble.AssemblyLine.al_general import ALIndividual, ALAddress
-from docassemble.base.functions import get_config
+from docassemble.base.functions import get_config, illegal_variable_name, TypeType
 from .efm_client import ApiResponse
+import importlib
+import dateutil.parser
 
 __all__ = [
   'convert_court_to_id',
@@ -22,8 +24,56 @@ __all__ = [
   'filter_payment_accounts',
   'payment_account_labels',
   'filing_id_and_label',
-  'get_tyler_roles'
+  'get_tyler_roles',
+  'transform_json_variables', 
 ]
+
+TypeType = type(type(None))
+
+def transform_json_variables(obj):
+    """A copy of docassemble's function in server.py (L25538). Can removed 
+    if https://github.com/jhpyle/docassemble/pull/541 is merged"""
+    if isinstance(obj, str):
+        if re.search(r'^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]', obj):
+            try:
+                return as_datetime(dateutil.parser.parse(obj))
+            except:
+                pass
+        elif re.search(r'^[0-9][0-9]:[0-9][0-9]:[0-9][0-9]', obj):
+            try:
+                return datetime.time.fromisoformat(obj)
+            except:
+                pass
+        return obj
+    if isinstance(obj, (bool, int, float)):
+        return obj
+    if isinstance(obj, dict):
+        if '_class' in obj and isinstance(obj['_class'], str) and 'instanceName' in obj and isinstance(obj['instanceName'], str) \
+          and obj['_class'].startswith('docassemble.base') and not illegal_variable_name(obj['_class']):
+            the_module = re.sub(r'\.[^\.]+$', '', obj['_class'])
+            try:
+                importlib.import_module(the_module)
+                the_class = eval(obj['_class'])
+                if not isinstance(the_class, TypeType):
+                    raise Exception("_class was not a class")
+                new_obj = the_class(obj['instanceName'])
+                for key, val in obj.items():
+                    if key == '_class':
+                        continue
+                    setattr(new_obj, key, transform_json_variables(val))
+                return new_obj
+            except Exception as err:
+                log("transform_json_variables: " + err.__class__.__name__ + ": " + str(err))
+                return None
+        new_dict = {}
+        for key, val in obj.items():
+            new_dict[transform_json_variables(key)] = transform_json_variables(val)
+        return new_dict
+    if isinstance(obj, list):
+        return [transform_json_variables(val) for val in obj]
+    if isinstance(obj, set):
+        return set(transform_json_variables(val) for val in obj)
+    return obj
 
 def convert_court_to_id(trial_court) -> str:
   if isinstance(trial_court, str):
@@ -260,6 +310,8 @@ def parse_service_contacts(service_list):
 
 def parse_case_info(proxy_conn, new_case:DAObject, entry:dict, court_id:str, *,
     fetch:bool=True, roles:dict=None):
+  if not roles:
+    roles = {}
   new_case.details = entry
   new_case.court_id = court_id
   new_case.tracking_id =  chain_xml(entry, ['value', 'caseTrackingID', 'value'])
@@ -292,6 +344,7 @@ def fetch_case_info(proxy_conn, new_case:DAObject, roles:dict=None):
   new_case.case_details = full_case_details.data or {}
   # TODO: is the order of this array predictable? might it break if Tyler changes something?
   new_case.case_type = new_case.case_details.get('value', {}).get('rest',[{},{}])[1].get('value',{}).get('caseTypeText',{}).get('value')
+  new_case.tyler_case_type = new_case.case_type
   new_case.title = chain_xml(new_case.case_details, ['value', 'caseTitleText', 'value'])
   new_case.date = tyler_daterep_to_datetime(
       chain_xml(new_case.case_details, ['value', 'activityDateRepresentation', 'value']))

--- a/docassemble/EFSPIntegration/data/questions/admin_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/admin_interview.yml
@@ -35,6 +35,12 @@ objects:
   - new_service_contact: ALIndividual
   - updated_service_contact: ALIndividual
 ---
+objects:
+  - case_search: EFCaseSearch
+---
+code: |
+  case_search.court_id = court_id
+---
 code: |
   user_admin_list = [
     ('get_user', 'Get User'),
@@ -277,18 +283,10 @@ content: |
   ${ action_button_html(url_ask(
     [{'undefine': [
       'do_what_choice',
-      'trial_court',
-      'court_id',
-      'can_file_non_indexed_case',
-      'display_case',
-      'case_search_task_status',
-      'case_search_waiting_screen',
-      'warn_no_results',
-      'case_was_found',
-      'found_case',
+      'case_search',
       'get_case_response',
     ]},
-    {'recompute': ['case_was_found', 'attach_service_contact', 'show_resp']}]),
+    {'recompute': ['case_search', 'case_search.case_was_found', 'attach_service_contact', 'show_resp']}]),
     label='Attach service contact', id_tag='attach_service_contact') }
 
   ${ action_button_html(url_ask(
@@ -356,61 +354,49 @@ content: |
 
   ${ action_button_html(url_ask(
     [{'undefine': [
-      'do_what_choice',
       'trial_court',
       'court_id',
-      'case_search_task_status',
-      'case_search_waiting_screen',
-      'warn_no_results',
-      'found_case',
+      'case_search',
       'get_case_response',
     ]},
-    {'recompute': ['case_was_found', 'display_case', 'display_found_case']}]),
+    {'recompute': ['case_search', 'case_search.case_was_found', 'case_search.display_case', 'display_found_case']}]),
     label="Find a case", id_tag="find_a_case") }
 
   ${ action_button_html(url_ask(
     [{'undefine': [
-      'do_what_choice',
+      'case_search',
       'trail_court',
       'court_id', 
-      'case_search_task_status',
-      'case_search_waiting_screen',
-      'warn_no_results',
-      'found_case',
       'get_case_response',
     ]},
-    {'recompute': ['case_was_found', 'get_service_information', 'show_resp']}]),
+    {'recompute': ['case_search', 'case_search.case_was_found', 'get_service_information', 'show_resp']}]),
     label="Get case service information", id_tag="get_case_service_info") }
     
   ${ action_button_html(url_ask(
     [{'undefine': [
-      'do_what_choice',
+      'case_search',
       'trial_court',
       'court_id',
-      'case_search_task_status',
-      'case_search_waiting_screen',
-      'warn_no_results',
-      'found_case',
       'get_case_response',
     ]},
-    {'recompute': ['case_was_found', 'get_service_information_history', 'show_resp']}]),
+    {'recompute': ['case_search', 'case_search.case_was_found', 'get_service_information_history', 'show_resp']}]),
     label="Get case service history", id_tag="get_case_service_info_history") }
     
 ---
 id: display case admin interview
 question: |
-  % if case_was_found:
+  % if case_search.case_was_found:
   Your case
   % else:
   No case found
   % endif
 subquestion: |
-  % if cms_connection_issue:
+  % if case_search.cms_connection_issue:
   The court’s case management system isn’t online. The case information might be out of date.
   % endif
   
-  % if case_was_found and found_case:
-  ${ found_case.title } (${ found_case.tracking_id })
+  % if case_search.case_was_found and case_search.found_case:
+  ${ case_search.found_case.title } (${ case_search.found_case.tracking_id })
   % endif
 continue button field: display_found_case
 ---
@@ -707,7 +693,7 @@ code: |
   resp = proxy_conn.create_waiver_account(new_account_name, new_account_is_global)
   globals().pop('new_account_name', None)
   globals().pop('new_account_is_global', None)
-  show_resp
+  reconsider('show_resp')
   new_payment_account = True 
 ---
 if: |
@@ -866,7 +852,10 @@ code: |
     updated_attorney.default_middle = ''
     updated_attorney.default_last = ''
     updated_attorney.default_bar_number = ''
-
+---
+code: |
+  all_party_type_options, all_party_type_map = \
+    choices_and_map(proxy_conn.get_party_types(court_id, None).data)
 ---
 code: |
   resp = proxy_conn.update_user(user_id, 
@@ -1310,14 +1299,14 @@ fields:
       all_case_parties  
 ---  
 code: |
-  all_case_parties = [(party.tyler_id, str(party.name)) for party in found_case.participants]
+  all_case_parties = [(party.tyler_id, str(party.name)) for party in case_search.found_case.participants]
 ---
 code: |
   if not service_contact_id:
     error_message = "You don't have any service contacts you can add." 
     show_error_event
-  if case_was_found:
-    resp = proxy_conn.attach_service_contact(service_contact_id, found_case.tracking_id, case_party_id)
+  if case_search.case_was_found:
+    resp = proxy_conn.attach_service_contact(service_contact_id, case_search.found_case.tracking_id, case_party_id)
     globals().pop('all_case_parties', None)
     globals().pop('service_contact_id', None)
     globals().pop('case_party_id', None)
@@ -1342,8 +1331,8 @@ code: |
   detach_service_contact = True
 ---
 code: |
-  if case_was_found:
-    resp = proxy_conn.get_service_information_history(court_id, found_case.tracking_id)
+  if case_search.case_was_found:
+    resp = proxy_conn.get_service_information_history(case_search.court_id, case_search.found_case.tracking_id)
     globals().pop('trial_court', None)
     globals().pop('court_id', None)
     get_service_information_history = True
@@ -1352,8 +1341,8 @@ code: |
     get_service_information_history = False
 ---
 code: |
-  if case_was_found:
-    resp = proxy_conn.get_service_information(court_id, found_case.tracking_id)
+  if case_search.case_was_found:
+    resp = proxy_conn.get_service_information(case_search.court_id, case_search.found_case.tracking_id)
     globals().pop('trial_court', None)
     globals().pop('court_id', None)
     get_service_information = True

--- a/docassemble/EFSPIntegration/data/questions/admin_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/admin_interview.yml
@@ -365,7 +365,7 @@ content: |
   ${ action_button_html(url_ask(
     [{'undefine': [
       'case_search',
-      'trail_court',
+      'trial_court',
       'court_id', 
       'get_case_response',
     ]},

--- a/docassemble/EFSPIntegration/data/questions/any_filing_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/any_filing_interview.yml
@@ -507,7 +507,7 @@ fields:
   - Case category: user_chosen_case_category
     datatype: dropdown
     code: |
-      sorted(stay_category_options, key=lambda cat: cat[1])
+      sorted(tyler_category_options, key=lambda cat: cat[1])
 ---
 id: case type
 question: |

--- a/docassemble/EFSPIntegration/data/questions/any_filing_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/any_filing_interview.yml
@@ -509,6 +509,9 @@ fields:
     code: |
       sorted(tyler_category_options, key=lambda cat: cat[1])
 ---
+code: |
+  tyler_category_options = case_category_options
+---
 id: case type
 question: |
   Case Type

--- a/docassemble/EFSPIntegration/data/questions/any_filing_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/any_filing_interview.yml
@@ -31,29 +31,35 @@ code: |
     ('FIRM_ADMIN_NEW_MEMBER', 'New member of current firm')
   ]
 ---
+objects:
+  - case_search: EFCaseSearch
+---
+code: |
+  case_search.court_id = court_id
+---
 mandatory: True
 code: |
   welcome
   tyler_login 
   trial_court
   can_check_efile
-  if not is_initial_filing and not case_was_found and not can_file_non_indexed_case:
+  if not is_initial_filing and not case_search.case_was_found and not case_search.can_file_non_indexed_case:
     failed_case_search
 
   if is_nonindexed_filing:
-      docket_number = non_indexed_docket_number
+      docket_number = case_search.non_indexed_docket_number
   if needs_all_info:
-    tyler_case_category = case_category_map.get(case_category,{}).get('code')
-    tyler_case_type = case_type_map.get(case_type,{}).get('code')
+    tyler_case_category = case_category_map.get(user_chosen_case_category,{}).get('code')
+    tyler_case_type = user_case_type
     if case_subtype_options:
       tyler_case_subtype = case_subtype_map.get(case_subtype).get('code')
     tyler_filing_attorney
     user_ask_role
     user_started_case
   else:
-    if case_was_found:
+    if case_search.case_was_found:
       load_existing_case_defaults
-      previous_case_id = found_case.tracking_id 
+      previous_case_id = case_search.found_case.tracking_id 
       user_started_case
       is_adding_new_parties
 
@@ -62,6 +68,8 @@ code: |
   existing_parties_new_atts.gather(complete_attribute='attorney_ids')
   attorney_ids
   party_to_attorneys
+  if not needs_all_info:
+    target_case = case_search
   all_case_parties
   if needs_all_info or showifdef('users[0].is_form_filler', False):
     lead_contact = users[0]
@@ -269,64 +277,6 @@ code: |
   else:
     al_form_type = 'existing_case'
 ---
-id: review_fees
-question: |
-  Review filing fees
-subquestion: |
-  Your payment account will be charged the following fees:
-  
-  % if has_fees:
-  ${ fees_table }
-  
-  **Total: ${ currency(fee_total(fees_resp)) }**
-  % else:
-  There are no fees associated with this filing.
-  % endif  
-fields:
-  - no label: review_fees
-    datatype: checkboxes
-    choices:
-      - ${ 'I agree to pay the listed fees of ' + str(currency(fee_total(fees_resp))) if has_fees else 'No fees' }: agrees_to_pay_fees
-    minlength: 1
-    validation messages:
-      minlength: |
-        You must agree to pay the fees listed above.
----
-id: bad fees
-event: bad_fees
-question: |
-  Something went wrong
-subquestion: |
-  Sorry, something went wrong when trying to figure out what fees you might have to pay.
- 
-  More details: ${ debug_display(fees_resp) }
----
-depends on:
-  - fees_resp
-code: |
-  has_fees = fee_total(fees_resp) and float(fee_total(fees_resp)) > 0
----
-code: |
-  fees_resp = proxy_conn.calculate_filing_fees(court_id, al_court_bundle)
-  if not fees_resp.is_ok():
-    log(f'fees not ok! {fees_resp}')
----
-depends on:
-  - fees_resp
-table: fees_table
-rows: |
-  [fee for fee in fees_resp.data.get('allowanceCharge',[]) if fee.get('chargeIndicator',{}).get('value')]
-columns:
-  - Reason: |
-      row_item.get('allowanceChargeReason',{}).get('value')
-  - Amount: |
-      currency(row_item.get('amount',{}).get('value',0))
----
-code: |
-  def fee_total(my_resp):
-    if my_resp.data:
-      return my_resp.data.get('feesCalculationAmount',{}).get('value')
----
 generic object: ALIndividual
 code: |
   str(x.name)
@@ -473,20 +423,20 @@ code: |
   is_initial_filing = filing_interview_initial_or_existing == 'initial_document'
 ---
 code: |
-  is_nonindexed_filing = not is_initial_filing and (not case_was_found and can_file_non_indexed_case)
+  is_nonindexed_filing = not is_initial_filing and (not case_search.case_was_found and case_search.can_file_non_indexed_case)
 ---
 code: |
   needs_all_info = is_initial_filing or is_nonindexed_filing
 ---
 code: |
-  selected_existing_case = found_case
+  selected_existing_case = case_search.found_case
 ---
 code: |
   if selected_existing_case:
     if selected_existing_case.category:
-      case_category = selected_existing_case.category
+      tyler_case_category = selected_existing_case.category
     if selected_existing_case.case_type:
-      case_type = selected_existing_case.case_type
+      tyler_case_type = selected_existing_case.case_type
     # TODO(brycew): get party info from existing case to select filing parties 
     existing_case_parties = None
   load_existing_case_defaults = True
@@ -526,7 +476,7 @@ fields:
   - To party: existing_parties_new_atts[i].existing_party
     datatype: select
     code: |
-      [(part.tyler_id, str(part.name)) for part in found_case.participants if part.tyler_id not in [ext_part.existing_party for ext_part in existing_parties_new_atts if defined('ext_part.existing_party')]]
+      [(part.tyler_id, str(part.name)) for part in case_search.found_case.participants if part.tyler_id not in [ext_part.existing_party for ext_part in existing_parties_new_atts if defined('ext_part.existing_party')]]
   - Attorneys: existing_parties_new_atts[i].attorney_adding_opts
     datatype: multiselect
     code: |
@@ -553,20 +503,20 @@ fields:
     code: |
       trial_court_options
 ---
-id: case category
+id: user chosen case category
 question: |
-  Case Category
+  What category is this case?
 fields:
-  - Case Category: case_category
+  - Case category: user_chosen_case_category
     datatype: dropdown
     code: |
-      sorted(case_category_options,key=lambda cat: cat[1])
+      sorted(stay_category_options, key=lambda cat: cat[1])
 ---
 id: case type
 question: |
   Case Type
 fields:
-  - Case Type: case_type
+  - Case Type: user_case_type
     datatype: dropdown
     code: |
       sorted(case_type_options,key=lambda cat: cat[1])
@@ -643,31 +593,6 @@ question:  |
 fields:
   - code: |
       users[0].name_fields(person_or_business='unknown' if not users[0].is_form_filler else 'ALIndividual', show_suffix=False)
----
-question: |
-  Are you this party?
-subquestion: |
-  Your information in the E-file system will be used
-fields:
-  - You are this party: users[0].is_form_filler
-    datatype: yesnoradio
----
-code: |
-  if i > 0:
-    users[i].is_form_filler = False
----
-code: |
-  # Can only get the attorney list for firm users, which can't be form fillers
-  if proxy_conn.get_attorney_list().is_ok():
-    users[0].is_form_filler = False
----
-code: |
-  if users[0].is_form_filler:
-    tyler_info = proxy_conn.get_user()
-    users[0].name.first = tyler_info.data.get('firstName')
-    users[0].name.middle = tyler_info.data.get('middleName', '')
-    users[0].name.last = tyler_info.data.get('lastName', '')
-    users[0].email = tyler_info.data.get('email')
 ---
 sets:
   - users[i].name.first
@@ -750,10 +675,10 @@ fields:
 code: |
   if is_initial_filing or users[0].is_form_filler:
     if showifdef('user_ask_role') == 'plaintiff':
-      plantiff = matching_tuple_option('plaintiff', party_type_options)
+      plaintiff = matching_tuple_option('plaintiff', party_type_options)
       petitioner = matching_tuple_option('petitioner', party_type_options)
-      if plantiff:
-        users[0].party_type_code = plantiff
+      if plaintiff:
+        users[0].party_type_code = plaintiff
       elif petitioner: 
         users[0].party_type_code = petitioner 
     else:
@@ -783,50 +708,6 @@ fields:
     code: |
       party_type_options if is_nonindexed_filing else party_type_new_options
     default: ${ matching_tuple_option('defendant', party_type_options) if showifdef('user_ask_role') == 'plaintiff' else matching_tuple_option('plaintiff', party_type_options) }
----
-# TODO(brycew): Need to force required filing types too
-code: |
-  def any_required(fc_opts, fc_map):
-    new_list = list(filter(lambda ff: fc_map.get(ff, {}).get('required'), fc_opts))
-    if new_list:
-      return True
-    else:
-      return False
-  def only_required_if_any(fc_opts, fc_map):
-    new_list = list(filter(lambda ff: fc_map.get(ff, {}).get('required'), fc_opts))
-    if new_list:
-      return new_list
-    else:
-      return fc_opts
----
-id: disclaimers
-question: |
-  Disclaimers
-subquestion: |
-  % if not disclaimers:
-  No Disclaimers!
-  % endif
-fields:
-  - no label: acknowledge_disclaimers
-    datatype: checkboxes
-    choices:
-      - I certify that I have read and followed the instructions below: user_agrees_to_disclaimers
-    minlength: 1
-    show if:
-      code: |
-        len(disclaimers)
-    validation messages:
-      minlength: |
-        You must acknowledge the disclaimers in order to continue
-        with your filing.
-under: |
-  % if disclaimers:
-  %for dis in disclaimers: 
-  
-  * ${ dis.get('requirementText') }
-  % endfor
-  % endif
-continue button field: show_disclaimers
 ---
 generic object: ALDocument
 id: reference number
@@ -941,7 +822,7 @@ code: |
   while not contacts_to_attach[i].contact_id:
     del contacts_to_attach[i].contact_id
     contacts_to_attach[i].contact_id
-  resp = proxy_conn.attach_service_contact(contacts_to_attach[i].contact_id, case_id=found_case.tracking_id)
+  resp = proxy_conn.attach_service_contact(contacts_to_attach[i].contact_id, case_id=case_search.found_case.tracking_id)
   log(f'attempted attaching {contacts_to_attach[i].contact_id}: {resp}')
   del resp
   contacts_to_attach[i].complete = True
@@ -990,13 +871,13 @@ fields:
     default: False
     show if:
       code: |
-        attached_service_contacts and (sum([u.is_new for u in users]) + sum([u.is_new for u in other_parties]) + sum([1 for pty in (found_case.participants if defined('found_case.participants') else [])])) > 0
+        attached_service_contacts and (sum([u.is_new for u in users]) + sum([u.is_new for u in other_parties]) + sum([1 for pty in (case_search.found_case.participants if defined('case_search.found_case.participants') else [])])) > 0
   - Which party is this contact for?: service_contacts[i].party_association
     datatype: radio
     required: False
     show if: service_contacts[i].attach_service_contact_to_party
     code: |
-      [{user.instanceName: str(user)} for user in users if user.is_new] + [{pty.instanceName: str(pty)} for pty in other_parties if pty.is_new] + [{part.tyler_id: str(part.name)} for part in (found_case.participants if defined('found_case.participants') else [])]
+      [{user.instanceName: str(user)} for user in users if user.is_new] + [{pty.instanceName: str(pty)} for pty in other_parties if pty.is_new] + [{part.tyler_id: str(part.name)} for part in (case_search.found_case.participants if defined('case_search.found_case.participants') else [])]
 continue button label: ${'Continue' if attached_service_contacts else 'Try again'}
 ---
 id: existing service contacts
@@ -1076,12 +957,12 @@ code: |
 ---
 code: |
   timing = 'Initial' if is_initial_filing else 'Subsequent'
-  case_type_options, case_type_map = choices_and_map(proxy_conn.get_case_types(court_id, case_category, timing=timing).data)
+  case_type_options, case_type_map = choices_and_map(proxy_conn.get_case_types(court_id, tyler_case_category, timing=timing).data)
   if not case_type_options:
     go_back_screen
 ---
 code: |
-  case_subtype_options, case_subtype_map = choices_and_map(proxy_conn.get_case_subtypes(court_id, case_type).data)
+  case_subtype_options, case_subtype_map = choices_and_map(proxy_conn.get_case_subtypes(court_id, tyler_case_type).data)
 ---
 code: |
   tyler_filing_attorney_options, tyler_filing_attorney_map = choices_and_map(proxy_conn.get_attorney_list().data, 
@@ -1095,22 +976,8 @@ code: |
   filing_attorney_required_datafield = proxy_conn.get_datafield(court_id, 'FilingFilingAttorneyView').data or {}
 ---
 code: |
-  disclaimers = proxy_conn.get_disclaimers(court_id).data
----
-code: |
-  party_type_options, party_type_map = \
-    choices_and_map(proxy_conn.get_party_types(court_id, case_type).data)
-  party_type_new_options = [p_type for p_type in party_type_options] 
-  # TODO(brycew): need to prevent multiple parties using the isAvailableForNewParties = False entries 
-  # if party_type_map[p_type[0]].get('isAvailableForNewParties')]
----
-generic object: ALDocument
-code: |
-  x.motion_type_options, x.motion_type_map = choices_and_map(proxy_conn.get_motion_types(court_id, x.filing_type).data)
----
-code: |
   service_type_options, service_type_map = choices_and_map(proxy_conn.get_service_types(court_id).data)
-  cross_ref_types, cross_ref_type_map = choices_and_map(proxy_conn.get_cross_references(court_id, case_type).data, backing='code')
+  cross_ref_types, cross_ref_type_map = choices_and_map(proxy_conn.get_cross_references(court_id, tyler_case_type).data, backing='code')
 ---
 code: |
   service_contact_options = parse_service_contacts(proxy_conn.get_service_contact_list().data)
@@ -1118,6 +985,6 @@ code: |
 code: |
   attached_service_contacts = []
   if not needs_all_info:
-    resp_data = proxy_conn.get_service_information(court_id, found_case.tracking_id).data
+    resp_data = proxy_conn.get_service_information(court_id, case_search.found_case.tracking_id).data
     attached_service_contacts = parse_service_contacts(resp_data)
 ---

--- a/docassemble/EFSPIntegration/data/questions/any_filing_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/any_filing_interview.yml
@@ -32,10 +32,7 @@ code: |
   ]
 ---
 objects:
-  - case_search: EFCaseSearch
----
-code: |
-  case_search.court_id = court_id
+  - case_search: EFCaseSearch.using(court_id=court_id)
 ---
 mandatory: True
 code: |

--- a/docassemble/EFSPIntegration/data/questions/case_search.yml
+++ b/docassemble/EFSPIntegration/data/questions/case_search.yml
@@ -8,119 +8,142 @@ modules:
 include:
   - login_qs.yml
 ---
-objects: 
-  - bg_found_cases: DAList.using(object_type=DAObject, auto_gather=False)  
----
+generic object: EFCaseSearch
 objects:
-  - somebody: ALIndividual
+  - x.somebody: ALIndividual
+---
+generic object: EFCaseSearch
+objects:
+  - x.found_cases: DAList.using(gathered=True)
 ---
 id: interview order
+generic object: EFCaseSearch
 comment: |
-  Main API of this YAML file. You should only depend on variables declared in this block. 
+  Main API of this YAML file. You should only depend on variables declared in this block.
+  To account for being able to search for multiple different cases in different courts,
+  all of these attributes are in a `EFCaseSearch` object.
 need:
-  - court_id
+  - x.court_id
 code: |
-  can_file_non_indexed_case
-  do_what_choice
-  found_case
-  if found_case and do_what_choice == 'docket_lookup':
-    display_case
-  if found_case is None and can_file_non_indexed_case:
-    non_indexed_docket_number
-  case_was_found = found_case is not None
+  x.can_file_non_indexed_case
+  x.do_what_choice
+  x.found_case
+  if x.found_case and x.do_what_choice == 'docket_lookup':
+    x.display_case
+  if x.found_case is None and x.can_file_non_indexed_case:
+    x.non_indexed_docket_number
+  x.case_was_found = x.found_case is not None
+---
+generic object: EFCaseSearch
+code: |
+  if x.case_search_task_status.ready():
+    if not x.case_search_task_status.failed():
+      x.tmp_dump = x.case_search_task_status.get()
+      x.cms_connection_issue = transform_json_variables(x.tmp_dump).get('retval') or None
+      x.found_cases = transform_json_variables(x.tmp_dump).get('retbal') or DAEmpty(x.instanceName + '.found_cases')
+    else:
+      log(x.case_search_task_status.result().error_message)
+      log(str(x.case_search_task_status.result().error_trace))
+      log(str(x.case_search_task_status.result().variables))
+      x.cms_connection_issue = False
+      x.found_cases = DAEmpty(x.instanceName + '.found_cases')
 ---
 only sets:
-  - found_case
+  - x.found_case
+generic object: EFCaseSearch
 if: |
-  do_what_choice == 'party_search'
+  x.do_what_choice == 'party_search'
 code: |
-  somebody.name.first
-  if not case_search_task_status.ready():
-    case_search_waiting_screen
+  x.somebody.name.first
+  if not x.case_search_task_status.ready():
+    x.case_search_waiting_screen
   else:
-    if found_cases.gathered and not found_cases: 
-      warn_no_results
-      found_case = None
+    x.cms_connection_issue
+    x.found_cases
+    if x.found_cases.gathered and x.found_cases:
+      x.found_case = x.case_choice
     else:
-      found_case = case_choice
-  del case_search_task_status
-  del somebody
-  globals().pop('found_cases', None)
-  globals().pop('case_choice', None)
+      x.warn_no_results
+      x.found_case = None
+  undefine('x.somebody', 'x.case_search_task_status',
+      'x.case_choice', 'x.found_cases')
 ---
 depends on:
-  - docket_id_from_user
+  - x.docket_id_from_user
+generic object: EFCaseSearch
 if: |
-  do_what_choice == 'docket_lookup'
+  x.do_what_choice == 'docket_lookup'
 code: |
-  docket_id_from_user
-  docket_case_response
-  if not docket_case_response.is_ok() or len(docket_case_response.data) == 0:
-    del docket_id_from_user
-    del docket_case_response
-    warn_no_results
-    found_case = None
+  x.docket_id_from_user
+  x.docket_case_response
+  if not x.docket_case_response.is_ok() or len(x.docket_case_response.data) == 0:
+    x.warn_no_results
+    x.found_case = None
   else:
-    court_id
-    found_case = DAObject('found_case')
-    parse_case_info(proxy_conn, found_case, docket_case_response.data[0], court_id)
-    del docket_id_from_user
-    del docket_case_response
+    x.court_id
+    x.found_case = DAObject(x.instanceName + '.found_case')
+    parse_case_info(proxy_conn, x.found_case, x.docket_case_response.data[0], x.court_id, fetch=True, roles=all_party_type_map)
+  undefine('x.docket_id_from_user', 'x.docket_case_response')
 ---
 only sets:
-  - found_case
+  - x.found_case
+generic object: EFCaseSearch
 if: |
-  do_what_choice == 'non_indexed_case'
+  x.do_what_choice == 'non_indexed_case'
 code: |
-  if can_file_non_indexed_case:
-    non_indexed_docket_number
-    found_case = None 
+  if x.can_file_non_indexed_case:
+    x.non_indexed_docket_number
+    x.found_case = None 
   else:
-    no_non_indexed_cases
-    found_case = None
+    x.no_non_indexed_cases
+    x.found_case = None
 ---
 only sets:
-  - can_file_non_indexed_case
+  - x.can_file_non_indexed_case
+generic object: EFCaseSearch
 code: |
-  court_code_results = proxy_conn.get_court(court_id).data
-  if court_code_results:
-    can_file_non_indexed_case = court_code_results.get('allowfilingintononindexedcase', False)
+  x.court_code_results = proxy_conn.get_court(x.court_id).data
+  if x.court_code_results:
+    x.can_file_non_indexed_case = x.court_code_results.get('allowfilingintononindexedcase', False)
   else:
-    can_file_non_indexed_case = False
+    x.can_file_non_indexed_case = False
 ---
+generic object: EFCaseSearch
 id: no non-indexed cases
 question: |
-  ${ court_id} does not allow filing into non-indexed cases
-continue button field: no_non_indexed_cases
+  ${ x.court_id} does not allow filing into non-indexed cases
+continue button field: x.no_non_indexed_cases
 ---
+generic object: EFCaseSearch
 id: no cases found
 question: |
   No cases found
 subquestion: |
-  % if cms_connection_issue:
+  % if x.cms_connection_issue:
   The court's case management system isn't online, and the case you are searching for might exist.
   % endif
 
-  % if can_file_non_indexed_case:
+  % if x.can_file_non_indexed_case:
   You can either continue to file into a non-indexed case or hit "${ word('back') }" to 
   try a new search.
   % else:
-  Unfortunately, ${ court_id } does not allow filing into non-indexed cases.
+  Unfortunately, ${ x.court_id } does not allow filing into non-indexed cases.
   % endif
-continue button field: warn_no_results
+continue button field: x.warn_no_results
 ---
+generic object: EFCaseSearch
 id: case lookup
 question: |
   Case lookup
 subquestion: |
-  % if can_file_non_indexed_case:
+  % if x.can_file_non_indexed_case:
   ${ collapse_template(explain_case_search_choices_template) }
   % endif
 fields:
-  - no label: do_what_choice
+  - no label: x.do_what_choice
     datatype: radio
     code: |
-      get_lookup_choices(can_file_non_indexed_case)
+      get_lookup_choices(x.can_file_non_indexed_case)
 ---
 template: explain_case_search_choices_template
 subject: |
@@ -132,7 +155,8 @@ content: |
   a clerk can match your filing to the case.
 ---
 sets:
-  - somebody.name.first
+  - x.somebody.name.first
+generic object: EFCaseSearch
 id: party name
 question: |
   Party name to find
@@ -140,136 +164,142 @@ subquestion: |
   Enter the name of a party involved in the case
 fields:
   code: |
-    somebody.name_fields(person_or_business='unknown')
+    x.somebody.name_fields(person_or_business='unknown')
 ---
-event: case_search_waiting_screen
+generic object: EFCaseSearch
+event: x.case_search_waiting_screen
 question: |
   <i class="fas fa-cog fa-spin"></i> Your search is in progress, please wait <i class="fas fa-cog fa-spin"></i>
 reload: True
 ---
 need:
-  - court_id
+  - x.court_id
+  - x.party_type_map
+generic object: EFCaseSearch
 code: |
-  case_search_task_status = background_action('case_search_task', 'refresh')
+  x.case_search_task_status = background_action('case_search_task', 'refresh', my_x=x)
 ---
 event: case_search_task
 code: |
-  background_response_action('case_search_done', cms_conn_and_cases=[*search_case_by_name(proxy_conn=proxy_conn,
-      var_name='found_cases', court_id=court_id, somebody=somebody, filter_fn=filter_fn)])
+  my_x = action_argument('my_x')
+  background_response(json_wrap(search_case_by_name(proxy_conn=proxy_conn,
+      var_name=my_x.instanceName + '.found_cases', court_id=my_x.court_id,
+      somebody=my_x.somebody, filter_fn=filter_fn, roles=my_x.party_type_map)))
 ---
-objects:
-  - found_cases: DAEmpty
----
-event: case_search_done
+generic object: EFCaseSearch
 code: |
-  globals().pop('start_case_idx', None)
-  globals().pop('end_case_idx', None)
-  cms_connection_issue, found_cases = action_argument('cms_conn_and_cases')
-  background_response()
+  x.party_type_map = all_party_type_map
 ---
 id: docket id
+generic object: EFCaseSearch
 question: |
   Case number
 subquestion: |
-  % if 'cook' in court_id:
-  ${ collapse_template(case_number_format_cook_county_template) }
-  % else:
   ${ collapse_template(case_number_format_template) }
-  % endif
 
 fields:
-  - Case number: docket_id_from_user
+  - Case number: x.docket_id_from_user
 ---
 id: ask non-indexed docket number
+generic object: EFCaseSearch
 question: |
   Case number
 subquestion: |
   Enter the case number for the non-indexed case
 
-  % if 'cook' in court_id:
-  ${ collapse_template(case_number_format_cook_county_template) }
-  % else:
   ${ collapse_template(case_number_format_template) }
-  % endif
   
 fields:
-  - Case number: non_indexed_docket_number
+  - Case number: x.non_indexed_docket_number
 # TODO: input validation is not possible--no required format for
 # case number in Illinois
 ---
+template: case_number_format_template
+subject: ""
+content: ""
+---
+if: |
+ jurisdiction_id == 'illinois'
 template: case_number_format_template
 subject: |
   How to enter your case number (Except Cook County)
 content: |
   [See information here](https://odysseyfileandserve.zendesk.com/hc/en-us/articles/360049682351-Illinois-What-is-the-correct-format-for-my-case-number-)
 ---
-template: case_number_format_cook_county_template
+if: |
+  jurisdiction_id == 'illinois' and 'cook' in x.court_id
+template: case_number_format_template
 subject: |
   How to enter your case number (Chicago/Cook County only)
 content: |
   [See information here](https://www.illinoislegalaid.org/legal-information/e-filing-tips-cook-county)
 ---
 if: |
-  do_what_choice == 'docket_lookup'
+  x.do_what_choice == 'docket_lookup'
+generic object: EFCaseSearch
 comment: |
   Long acting action
 need:
   - proxy_conn.authed_user_id
 depends on:
-  - docket_id_from_user
+  - x.docket_id_from_user
 code: |
-  docket_case_response = proxy_conn.get_cases(court_id, docket_id=docket_id_from_user)
-  cms_connection_issue = docket_case_response.response_code == 203
+  x.docket_case_response = proxy_conn.get_cases(x.court_id, docket_id=x.docket_id_from_user)
+  x.cms_connection_issue = x.docket_case_response.response_code == 203
 ---
 need:
-  - found_cases
+  - x.found_cases
 depends on:
-  - found_cases
-id: results for case search 
+  - x.found_cases
+id: results for case search
+generic object: EFCaseSearch
 question: |
   Case Search Results
 subquestion: |
-  % if cms_connection_issue:
+  % if x.cms_connection_issue:
   The court's case management system isn't online. The case information might be out of date.
   % endif
 
-  We found ${ len(found_cases) } ${ noun_plural("case", found_cases) }
-  % if len(found_cases) > num_case_choices():
-  . Here are ${ start_case_idx + 1 } to ${ end_case_idx }
+  We found ${ len(x.found_cases) } ${ noun_plural("case", x.found_cases) }
+  % if len(x.found_cases) > num_case_choices():
+  . Here are ${ x.start_case_idx + 1 } to ${ x.end_case_idx }
   % endif
   :
 
-  ${ action_button_html(url_action('shift_cases_window', direction='prev'), label='Prev') if start_case_idx > 0 else '' }
-  ${ action_button_html(url_action('shift_cases_window', direction='next'), label='Next') if end_case_idx < len(found_cases) else ''}
+  ${ action_button_html(url_action('x.shift_cases_window', direction='prev'), label='Prev') if x.start_case_idx > 0 else '' }
+  ${ action_button_html(url_action('x.shift_cases_window', direction='next'), label='Next') if x.end_case_idx < len(x.found_cases) else ''}
   
-  % for case in found_cases[start_case_idx:end_case_idx]:
+  % for case in x.found_cases[x.start_case_idx:x.end_case_idx]:
   * ${ case.title } (${ case.date })
   % endfor
 
-  ${ collapse_template(case_results_template) }
+  ${ collapse_template(x.case_results_template) }
 
 fields:
-  - Which case?: case_choice
+  - Which case?: x.case_choice
     datatype: object 
     object labeler: |
       lambda case: f"{getattr(case, 'docket_id', '')} {getattr(case, 'title', '')} ({getattr(case, 'date', '')})"
     choices:
-      - found_cases[start_case_idx:end_case_idx]
+      - x.found_cases[x.start_case_idx:x.end_case_idx]
 ---
-event: shift_cases_window
+generic object: EFCaseSearch
+event: x.shift_cases_window
 code: |
-  start_case_idx, end_case_idx = shift_case_select_window(proxy_conn, found_cases,
-    direction=action_argument('direction'), start_idx=start_case_idx, end_idx=end_case_idx)
+  x.start_case_idx, x.end_case_idx = shift_case_select_window(proxy_conn, x.found_cases,
+    direction=action_argument('direction'), start_idx=x.start_case_idx, end_idx=x.end_case_idx)
 ---
+generic object: EFCaseSearch
 code: |
-  start_case_idx = 0
-  end_case_idx = min(len(found_cases), num_case_choices())
+  x.start_case_idx = 0
+  x.end_case_idx = min(len(x.found_cases), num_case_choices())
 ---
-template: case_results_template
+template: x.case_results_template
+generic object: EFCaseSearch
 subject: |
   View case data
 content: |
-  % for case in found_cases[start_case_idx:end_case_idx]:
+  % for case in x.found_cases[x.start_case_idx:x.end_case_idx]:
   #### ${ case.title } (${ case.date })
   * DocketID: ${ case.docket_id }
   * CourtID: ${ case.court_id }
@@ -277,19 +307,20 @@ content: |
   % endfor
 ---
 id: display case
-continue button field: display_case
+generic object: EFCaseSearch
+continue button field: x.display_case
 question: |
   Your case was found
 subquestion: |
-  % if cms_connection_issue:
+  % if x.cms_connection_issue:
   The court's case management system isn't online. The case information might be out of date.
   % endif
   
-  % if found_case:
-  #### ${ found_case.title} (${ found_case.date })
-  * DocketID: ${ found_case.docket_id }
-  * CourtID: ${ found_case.court_id }
-  * CaseCategory: ${ found_case.category }
+  % if x.found_case:
+  #### ${ x.found_case.title} (${ x.found_case.date })
+  * DocketID: ${ x.found_case.docket_id }
+  * CourtID: ${ x.found_case.court_id }
+  * CaseCategory: ${ x.found_case.category }
   % endif
 ---
 comment: |
@@ -298,3 +329,85 @@ comment: |
 code: |
   def filter_fn(new_case):
     return True
+---
+#########################################
+## Populating Case Parties based on the case search
+#########################################
+---
+need:
+  - users
+  - is_user_party
+  - is_other_party
+  - other_parties
+  - target_case.found_case
+code: |
+  if not target_case.self_in_case:
+    users.appendObject()
+    users[0].is_new = True
+    to_add_participants = target_case.found_case.participants
+  else:
+    target_case.self_partip_choice.is_new = False
+    # Change where DA thinks this obj came from, so it says "you", and not "NAME"
+    users.append(target_case.self_partip_choice.copy_deep('users[0]'))
+    to_add_participants = [p for p in target_case.found_case.participants if p.instanceName != target_case.self_partip_choice.instanceName]
+
+  for partip in to_add_participants:
+    partip.is_new = False
+    if is_user_party(partip):
+      users.append(partip.copy_deep(f'users[{len(users.elements)}]'))
+    elif is_other_party(partip):
+      other_parties.append(partip.copy_deep(f'other_parties[{len(other_parties.elements)}]'))
+    else:
+      log(f'partip: ${partip} has weird role: ${partip.party_type}')
+  add_existing_users = True
+---
+comment: |
+  TODO(brycew): should be attached to the DACaseSearch, but have had problems with lambda attributes
+only sets:
+  - is_user_party
+  - is_other_party
+code: |
+  def is_defendant_party(p):
+    return p.party_type == '20641' or \
+        (p.party_type_name is not None and 'defendant' in p.party_type_name.lower())
+  
+  def is_plaintiff_party(p):
+    return p.party_type == '20646' or \
+        (p.party_type_name is not None and 'plaintiff' in p.party_type_name.lower())
+  
+  if user_ask_role == 'plaintiff':
+    is_user_party = is_plaintiff_party
+    is_other_party = is_defendant_party
+  else:
+    is_user_party = is_defendant_party
+    is_other_party = is_plaintiff_party
+---
+generic object: EFCaseSearch
+question: |
+  % if len(x.maybe_user_partips) == 1:
+  We found this participant in the existing case
+  % else:
+  We found these participants in the existing case
+  % endif
+subquestion: |
+  % if len(x.maybe_user_partips) == 1:
+  Are you ${ x.maybe_user_partips[0] }?
+  % elif len(x.maybe_user_partips) > 1:
+  % for partip in x.maybe_user_partips:
+  * ${ partip }
+  % endfor
+  
+  Are you any of the above participants?
+  % endif
+fields:
+  - no label: x.self_in_case
+    datatype: yesnomaybe
+  - I am: x.self_partip_choice
+    datatype: object_radio
+    choices: |
+      x.maybe_user_partips
+    show if: x.self_in_case
+---
+generic object: EFCaseSearch
+code: |
+  x.maybe_user_partips = [partip for partip in x.found_case.participants if is_user_party(partip)]

--- a/docassemble/EFSPIntegration/data/questions/case_search.yml
+++ b/docassemble/EFSPIntegration/data/questions/case_search.yml
@@ -38,9 +38,9 @@ generic object: EFCaseSearch
 code: |
   if x.case_search_task_status.ready():
     if not x.case_search_task_status.failed():
-      x.tmp_dump = x.case_search_task_status.get()
-      x.cms_connection_issue = transform_json_variables(x.tmp_dump).get('retval') or None
-      x.found_cases = transform_json_variables(x.tmp_dump).get('retbal') or DAEmpty(x.instanceName + '.found_cases')
+      x.tmp_dump = json_unwrap(x.case_search_task_status.get())
+      x.cms_connection_issue = x.tmp_dump[0] or None
+      x.found_cases = x.tmp_dump[1] or DAEmpty(x.instanceName + '.found_cases')
     else:
       log(x.case_search_task_status.result().error_message)
       log(str(x.case_search_task_status.result().error_trace))

--- a/docassemble/EFSPIntegration/data/questions/case_search.yml
+++ b/docassemble/EFSPIntegration/data/questions/case_search.yml
@@ -38,7 +38,8 @@ generic object: EFCaseSearch
 code: |
   if x.case_search_task_status.ready():
     if not x.case_search_task_status.failed():
-      x.tmp_dump = json_unwrap(x.case_search_task_status.get())
+      x.tmp_obj = x.case_search_task_status.get()
+      x.tmp_dump = json_unwrap(x.tmp_obj)
       x.cms_connection_issue = x.tmp_dump[0] or None
       x.found_cases = x.tmp_dump[1] or DAEmpty(x.instanceName + '.found_cases')
     else:

--- a/docassemble/EFSPIntegration/data/questions/codes_helper.yml
+++ b/docassemble/EFSPIntegration/data/questions/codes_helper.yml
@@ -202,7 +202,7 @@ code: |
   filing_description_datafield = proxy_conn.get_datafield(court_id, 'FilingFilingDescription').data or {}
 ---
 code: |
-  filing_type_options, filing_type_map = choices_and_map(proxy_conn.get_filing_types(court_id, case_category, case_type, is_initial_filing).data)
+  filing_type_options, filing_type_map = choices_and_map(proxy_conn.get_filing_types(court_id, tyler_case_category, tyler_case_type, is_initial_filing).data)
 ---
 code: |
   if needs_all_info or any([u.is_new for u in users]):
@@ -211,7 +211,7 @@ code: |
     all_case_parties_tmp = []
 
   if not needs_all_info:
-    all_case_parties_tmp.extend([[party.tyler_id, str(party.name)] for party in found_case.participants])
+    all_case_parties_tmp.extend([[party.tyler_id, str(party.name)] for party in target_case.found_case.participants])
 
   all_case_parties = all_case_parties_tmp
   del all_case_parties_tmp
@@ -222,7 +222,18 @@ code: |
 ---
 code: |
   timing = 'Initial' if is_initial_filing else 'Subsequent'
-  case_type_options, case_type_map = choices_and_map(proxy_conn.get_case_types(court_id, case_category, timing=timing).data)
+  case_type_options, case_type_map = choices_and_map(proxy_conn.get_case_types(court_id, tyler_case_category, timing=timing).data)
+---
+code: |
+  party_type_options, party_type_map = \
+    choices_and_map(proxy_conn.get_party_types(court_id, tyler_case_type).data)
+  party_type_new_options = [p_type for p_type in party_type_options] 
+  # TODO(brycew): need to prevent multiple parties using the isAvailableForNewParties = False entries 
+  # if party_type_map[p_type[0]].get('isAvailableForNewParties')]
+---
+code: |
+  all_party_type_options, all_party_type_map = \
+    choices_and_map(proxy_conn.get_party_types(court_id, None).data)
 ---
 code: |
   def exactly_one_required_filing_component(fc_opts, fc_map) -> bool:
@@ -269,3 +280,124 @@ only sets: full_court_info
 code: |
   full_court_info = get_full_court_info(proxy_conn, court_id)
 ---
+################################
+## Fees
+id: review_fees
+question: |
+  Review filing fees
+subquestion: |
+  Your payment account will be charged the following fees:
+  
+  % if has_fees:
+  ${ fees_table }
+  
+  **Total: ${ currency(fee_total(fees_resp)) }**
+  % else:
+  There are no fees associated with this filing.
+  % endif  
+fields:
+  - no label: review_fees
+    datatype: checkboxes
+    choices:
+      - ${ 'I agree to pay the listed fees of ' + str(currency(fee_total(fees_resp))) if has_fees else 'No fees' }: agrees_to_pay_fees
+    minlength: 1
+    validation messages:
+      minlength: |
+        You must agree to pay the fees listed above.
+---
+id: bad fees
+event: bad_fees
+question: |
+  Something went wrong
+subquestion: |
+  Sorry, something went wrong when trying to figure out what fees you might have to pay.
+ 
+  More details: ${ debug_display(fees_resp) }
+---
+depends on:
+  - fees_resp
+code: |
+  has_fees = fee_total(fees_resp) and float(fee_total(fees_resp)) > 0
+---
+code: |
+  fees_resp = proxy_conn.calculate_filing_fees(court_id, al_court_bundle)
+  if not fees_resp.is_ok():
+    log(f'fees not ok! {fees_resp}')
+---
+depends on:
+  - fees_resp
+table: fees_table
+rows: |
+  [fee for fee in fees_resp.data.get('allowanceCharge',[]) if fee.get('chargeIndicator',{}).get('value')]
+columns:
+  - Reason: |
+      row_item.get('allowanceChargeReason',{}).get('value')
+  - Amount: |
+      currency(row_item.get('amount',{}).get('value',0))
+---
+code: |
+  def fee_total(my_resp):
+    if my_resp.data:
+      return my_resp.data.get('feesCalculationAmount',{}).get('value')
+---
+#############################
+## is_form_filler
+question: |
+  Are you this party?
+subquestion: |
+  Your information in the E-file system will be used
+fields:
+  - You are this party: users[0].is_form_filler
+    datatype: yesnoradio
+---
+code: |
+  if i > 0:
+    users[i].is_form_filler = False
+---
+code: |
+  # Can only get the attorney list for firm users, which can't be form fillers
+  if proxy_conn.get_attorney_list().is_ok():
+    users[0].is_form_filler = False
+---
+need: proxy_conn
+if: users[0].is_form_filler
+code: |
+  tyler_info = proxy_conn.get_user()
+  users[0].name.first = tyler_info.data.get('firstName')
+  users[0].name.middle = tyler_info.data.get('middleName', '')
+  users[0].name.last = tyler_info.data.get('lastName', '')
+  users[0].email = tyler_info.data.get('email')
+---
+########################
+## disclaimer
+id: disclaimers
+question: |
+  Disclaimers
+subquestion: |
+  % if not disclaimers:
+  No Disclaimers!
+  % endif
+fields:
+  - no label: acknowledge_disclaimers
+    datatype: checkboxes
+    choices:
+      - I certify that I have read and followed the instructions below: user_agrees_to_disclaimers
+    minlength: 1
+    show if:
+      code: |
+        len(disclaimers)
+    validation messages:
+      minlength: |
+        You must acknowledge the disclaimers in order to continue
+        with your filing.
+under: |
+  % if disclaimers:
+  %for dis in disclaimers: 
+  
+  * ${ dis.get('requirementText') }
+  % endfor
+  % endif
+continue button field: show_disclaimers
+---
+code: |
+  disclaimers = proxy_conn.get_disclaimers(court_id).data

--- a/docassemble/EFSPIntegration/data/questions/common_qs.yml
+++ b/docassemble/EFSPIntegration/data/questions/common_qs.yml
@@ -63,7 +63,9 @@ fields:
     code: |
       trial_court_options
 ---
-only sets: trial_court_options
 code: |
   trial_court_resp = proxy_conn.get_courts(fileable_only=True, with_names=True)
   trial_court_options = sorted([(court['code'], court['name']) for court in trial_court_resp.data or []], key=lambda c: c[1])
+  trial_court_map = {court['code']: court['name'] for court in trial_court_resp.data or []}
+  if defined('court_id'):
+    trial_court = trial_court_map[court_id]

--- a/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
+++ b/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
@@ -68,11 +68,11 @@ help:
   content: |
     Some additional information:
     
-    % if defined('case_category') and defined('case_category_map'):
-    * Case category: ${ case_category } ${ case_category_map.get(case_category) }
+    % if defined('tyler_case_category') and defined('case_category_map'):
+    * Case category: ${ tyler_case_category } ${ case_category_map.get(tyler_case_category) }
     % endif
-    % if defined('case_type') and defined('case_type_map'):
-    * Case type: ${ case_type } ${ case_type_map.get(case_type) }
+    % if defined('tyler_case_type') and defined('case_type_map'):
+    * Case type: ${ tyler_case_type } ${ case_type_map.get(tyler_case_type) }
     % endif
     % if defined('al_court_bundle[0].tyler_filing_type'):
     * Lead document type: ${ al_court_bundle[0].tyler_filing_type }
@@ -123,6 +123,7 @@ comment: |
   ${ action_button_html(url_ask([{'recompute': ['efile']}]),
      label='E-file') }
 ---
+id: something wrong when submitting
 question: |
   Something went wrong when submitting
 subquestion: |
@@ -144,6 +145,7 @@ fields:
   - Do you want to efile?: user_wants_efile
     datatype: yesnoradio
 ---
+id: you-will-not-be-able-to-efile
 question: |
   You will *not* be able to efile this document
 subquestion: |
@@ -152,6 +154,7 @@ subquestion: |
   However, you are still be able to continue and download a completed form.
 continue button field: show_no_efile
 ---
+id: missing-fields
 question: |
   Missing fields
 subquestion: |
@@ -194,7 +197,7 @@ subquestion: |
 
   % endif
 
-continue button field: show_remaining
+event: show_remaining
 ---
 objects:
   - follow_up_vars: DADict
@@ -344,6 +347,7 @@ id: separate efile
 code: |
   efile_resp = proxy_conn.file_for_review(court_id, al_court_bundle)
 ---
+id: which-court-date
 question: |
   Which court date would you like ?
 fields:
@@ -388,6 +392,7 @@ subquestion: |
   ${ pretty_display(submitted_court_reserve_resp.data) }
 continue button field: show_court_reserve_resp
 ---
+id: missing-field-redo
 generic object: DAObject
 question: |
   Missing Field: ${ x[i].name }

--- a/docassemble/EFSPIntegration/data/questions/unauthenticated_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/unauthenticated_interview.yml
@@ -91,7 +91,7 @@ subquestion: |
   
   [Resend activation email](${ url_ask([{'recompute': ['self_resend_activation','show_resp']}]) })
 
-  % else
+  % else:
   ${ debug_display(resp) }
   % endif
 

--- a/docassemble/EFSPIntegration/data/sources/admin_interview.feature
+++ b/docassemble/EFSPIntegration/data/sources/admin_interview.feature
@@ -105,9 +105,9 @@ Feature: The interviews run without erroring
     And I tap the "#attach_service_contact" element
     And I set the variable "trial_court" to "peoria"
     And I tap to continue
-    And I set the variable "do_what_choice" to "docket_lookup"
+    And I set the variable "x.do_what_choice" to "docket_lookup"
     And I tap to continue
-    And I set the variable "docket_id_from_user" to "22-AD-00005"
+    And I set the variable "x.docket_id_from_user" to "22-AD-00005"
     And I tap to continue
     And I see the phrase "IMPOUNDED ADOPTION"
     And I tap to continue
@@ -120,9 +120,9 @@ Feature: The interviews run without erroring
     And I tap the "#attach_service_contact" element
     And I set the variable "trial_court" to "peoria"
     And I tap to continue
-    And I set the variable "do_what_choice" to "docket_lookup"
+    And I set the variable "x.do_what_choice" to "docket_lookup"
     And I tap to continue
-    And I set the variable "docket_id_from_user" to "22-AD-00005"
+    And I set the variable "x.docket_id_from_user" to "22-AD-00005"
     And I tap to continue
     And I see the phrase "IMPOUNDED ADOPTION"
     And I tap to continue
@@ -145,9 +145,9 @@ Feature: The interviews run without erroring
     And I tap the "#attach_service_contact" element
     And I set the variable "trial_court" to "peoria"
     And I tap to continue
-    And I set the variable "do_what_choice" to "docket_lookup"
+    And I set the variable "x.do_what_choice" to "docket_lookup"
     And I tap to continue
-    And I set the variable "docket_id_from_user" to "22-AD-00005"
+    And I set the variable "x.docket_id_from_user" to "22-AD-00005"
     And I tap to continue
     And I see the phrase "IMPOUNDED ADOPTION"
     And I tap to continue

--- a/docassemble/EFSPIntegration/data/sources/any_filing_interview.feature
+++ b/docassemble/EFSPIntegration/data/sources/any_filing_interview.feature
@@ -17,8 +17,8 @@ Feature: Make any type of filing
       | var | value | trigger |
       | trial_court | peoria | |
       | filing_interview_initial_or_existing | existing_case | |
-      | do_what_choice | docket_lookup | |
-      | docket_id_from_user | 22-AD-00005 | |
+      | x.do_what_choice | docket_lookup | case_search.do_what_choice |
+      | x.docket_id_from_user | 22-AD-00005 | case_search.docket_id_from_user |
       | user_ask_role | defendant | |
       | is_adding_new_parties | False | |
       | other_parties.there_are_any | False | |
@@ -64,8 +64,8 @@ Feature: Make any type of filing
       | var | value | trigger |
       | trial_court | peoria | |
       | filing_interview_initial_or_existing | existing_case | |
-      | do_what_choice | docket_lookup | |
-      | docket_id_from_user | 22-AD-00005 | |
+      | x.do_what_choice | docket_lookup | case_search.do_what_choice |
+      | x.docket_id_from_user | 22-AD-00005 | case_search.docket_id_from_user |
       | user_ask_role | defendant | |
       | is_adding_new_parties | False | |
       | other_parties.there_are_any | False | |
@@ -111,14 +111,14 @@ Feature: Make any type of filing
       And I tap to continue
       And I set the variable "filing_interview_initial_or_existing" to "existing_case"
       And I tap to continue
-      And I set the variable "do_what_choice" to "party_search"
+      And I set the variable "x.do_what_choice" to "party_search"
       And I tap to continue
-      And I set the variable "somebody.person_type" to "ALIndividual"
-      And I set the variable "somebody.name.first" to "John"
-      And I set the variable "somebody.name.last" to "Brown"
+      And I set the variable "case_search.somebody.person_type" to "ALIndividual"
+      And I set the variable "case_search.somebody.name.first" to "John"
+      And I set the variable "case_search.somebody.name.last" to "Brown"
       And I tap to continue
       And I wait 30 seconds
-      And I set the variable "case_choice" to "found_cases[1]"
+      And I set the variable "x.case_choice" to "case_search.found_cases[1]"
       And I tap to continue
       And I set the variable "user_ask_role" to "defendant"
       And I tap to continue

--- a/docassemble/EFSPIntegration/data/sources/unauthenticated_interview.feature
+++ b/docassemble/EFSPIntegration/data/sources/unauthenticated_interview.feature
@@ -1,0 +1,7 @@
+@interviews_start
+Feature: The unauthenticated interview starts without erroring
+
+  @ui1 @unauthenticated
+  Scenario: unauthenticated_interview.yml starts
+    Given I start the interview at "unauthenticated_interview.yml"
+    And the maximum seconds for each Step in this Scenario is 15

--- a/docassemble/EFSPIntegration/efm_client.py
+++ b/docassemble/EFSPIntegration/efm_client.py
@@ -26,6 +26,7 @@ def state_name_to_code(state_name:str) -> str:
 
 class ApiResponse:
   def __init__(self, response_code: int, error_msg:Optional[str], data):
+    self.instanceName = 'not_real'
     self.response_code = response_code
     self.error_msg = error_msg
     self.data = data
@@ -62,7 +63,8 @@ def _get_all_vars(bundle: ALDocumentBundle):
   all_vars_dict = all_variables()
   vars_to_pop = ['trial_court_resp', 'x', 'trial_court_options', 'found_case', 'selected_existing_case', 
       'filing_type_options', 'filing_type_map', 'party_type_options',
-      'available_efile_courts', 'case_category_map']
+      'available_efile_courts', 'case_category_map', 'full_court_info', 'tyler_login_resp', 'case_type_map', 'all_courts', 
+      'al_user_bundle', 'court_emails', 'party_type_map']
   for var in vars_to_pop:
     all_vars_dict.pop(var, None)
 
@@ -564,7 +566,7 @@ class ProxyConnection:
         data=json.dumps({'doc_id': doc_id, 'estimated_duration': estimated_duration, 'range_after' : range_after, 'range_before': range_before}))
     return self._call_proxy(send)
   
-  def get_cases(self, court_id:str, person:ALIndividual=None, docket_id:str=None):
+  def get_cases(self, court_id:str, person:ALIndividual=None, docket_id:str=None) -> ApiResponse:
     if person is None:
       return self._get_cases(court_id, docket_id=docket_id)
     if person.person_type == 'business':
@@ -637,8 +639,11 @@ class ProxyConnection:
     send = lambda: self.proxy_client.get(self.full_url(f'codes/courts/{court_id}/service_types'))
     return self._call_proxy(send)
   
-  def get_party_types(self, court_id:str, case_type_id:str):
-    send = lambda: self.proxy_client.get(self.full_url(f'codes/courts/{court_id}/case_types/{case_type_id}/party_types'))
+  def get_party_types(self, court_id:str, case_type_id:Optional[str]):
+    if case_type_id:
+      send = lambda: self.proxy_client.get(self.full_url(f'codes/courts/{court_id}/case_types/{case_type_id}/party_types'))
+    else:
+      send = lambda: self.proxy_client.get(self.full_url(f'codes/courts/{court_id}/party_types'))
     return self._call_proxy(send)
   
   def get_document_types(self, court_id:str, filing_type:str):

--- a/docassemble/EFSPIntegration/interview_logic.py
+++ b/docassemble/EFSPIntegration/interview_logic.py
@@ -33,7 +33,7 @@ def json_wrap(item:Tuple):
   return safe_json([*item])
 
 def json_unwrap(val):
-  return transform_json_variables(json.loads(val))
+  return transform_json_variables(val)
 
 def search_case_by_name(*, proxy_conn, var_name:str=None, 
     court_id:str, somebody, filter_fn:Callable[[Any], bool], roles=None) -> Tuple[bool, DAList]:

--- a/docassemble/EFSPIntegration/interview_logic.py
+++ b/docassemble/EFSPIntegration/interview_logic.py
@@ -1,8 +1,10 @@
 from typing import Any, Callable, Dict, List, Tuple, Optional, Iterable, Union
 
+import json
+
 from docassemble.base.util import DAObject, DAList, log
-from docassemble.base.functions import serializable_dict
-from .conversions import parse_case_info, fetch_case_info
+from docassemble.base.functions import safe_json
+from .conversions import parse_case_info, fetch_case_info, transform_json_variables
 from docassemble.AssemblyLine.al_general import ALPeopleList
 
 class EFCaseSearch(DAObject):
@@ -27,8 +29,11 @@ def get_lookup_choices(can_file_non_indexed_case:bool) -> List[Dict[str, str]]:
     lookup_choices.append({'non_indexed_case': 'I want to file into a non-indexed case'})
   return lookup_choices
 
-def json_wrap(item):
-  return serializable_dict({'retval': item[0], 'retbal': item[1]})
+def json_wrap(item:Tuple):
+  return safe_json([*item])
+
+def json_unwrap(val):
+  return transform_json_variables(json.loads(val))
 
 def search_case_by_name(*, proxy_conn, var_name:str=None, 
     court_id:str, somebody, filter_fn:Callable[[Any], bool], roles=None) -> Tuple[bool, DAList]:

--- a/docassemble/EFSPIntegration/interview_logic.py
+++ b/docassemble/EFSPIntegration/interview_logic.py
@@ -1,8 +1,17 @@
 from typing import Any, Callable, Dict, List, Tuple
 
 from docassemble.base.util import DAObject, DAList, log
+from docassemble.base.functions import serializable_dict
 from .conversions import parse_case_info, fetch_case_info
 from docassemble.AssemblyLine.al_general import ALPeopleList
+
+class EFCaseSearch(DAObject):
+  court_id:str
+  can_file_non_indexed_case: bool
+  do_what_choice: str
+  found_case: DAObject
+  case_was_found: bool
+
 
 def num_case_choices() -> int:
   """The number of cases that someone should have to choose between if there are too many.
@@ -18,8 +27,11 @@ def get_lookup_choices(can_file_non_indexed_case:bool) -> List[Dict[str, str]]:
     lookup_choices.append({'non_indexed_case': 'I want to file into a non-indexed case'})
   return lookup_choices
 
+def json_wrap(item):
+  return serializable_dict({'retval': item[0], 'retbal': item[1]})
+
 def search_case_by_name(*, proxy_conn, var_name:str=None, 
-    court_id:str, somebody, filter_fn:Callable[[Any], bool]) -> Tuple[bool, DAList]:
+    court_id:str, somebody, filter_fn:Callable[[Any], bool], roles=None) -> Tuple[bool, DAList]:
   """Searches for cases by party name. If there are more than 10 cases found, we don't
     add all of the detailed information about the case, just for the first few cases"""
   if not var_name:
@@ -33,7 +45,7 @@ def search_case_by_name(*, proxy_conn, var_name:str=None,
     for idx, entry in enumerate(reversed(get_cases_response.data)):
       new_case = found_cases.appendObject()
       should_fetch = idx < num_case_choices()
-      parse_case_info(proxy_conn, new_case, entry, court_id, fetch=should_fetch, roles={})
+      parse_case_info(proxy_conn, new_case, entry, court_id, fetch=should_fetch, roles=roles)
       # Allows users to control what cases are shown as options
       if not filter_fn(new_case):
         found_cases.pop()
@@ -75,3 +87,31 @@ def get_full_court_info(proxy_conn, court_id:str) -> Dict:
   else:
     log(f"Couldn't get full court info for {court_id}")
     return {}
+
+def filter_codes(options, filters, default:str):
+  """Given a list of filter functions from most specific to least specific,
+  (if true, use that code)
+  filters a total list of codes"""
+  codes_tmp = []
+  strs = all([isinstance(fs, str) for fs in filters]) 
+  for filter_fn in filters:
+    if codes_tmp:
+      break
+    if isinstance(filter_fn, str):
+      match_this = filter_fn
+      filter_fn = lambda opt: opt[1].lower() == match_this.lower()
+    codes_tmp = [opt for opt in options if filter_fn(opt)]
+  if not codes_tmp and strs:
+    for filter_st in filters:
+      if codes_tmp:
+        break
+      filter_fn = lambda opt: filter_st.lower() in opt[1].lower()
+      codes_tmp = [opt for opt in options if filter_fn(opt)]
+
+  codes = sorted(codes_tmp, key=lambda option: option[1])
+  if len(codes) == 1:
+    return codes, codes[0][0]
+  elif len(codes) == 0:
+    return codes, default
+  else:
+    return codes, None

--- a/docassemble/EFSPIntegration/requirements.txt
+++ b/docassemble/EFSPIntegration/requirements.txt
@@ -4,3 +4,4 @@ docassemble.AssemblyLine>2.10.1
 requests>2.25.1
 types-requests
 mypy
+types-python-dateutil

--- a/docassemble/EFSPIntegration/test/integration_test.py
+++ b/docassemble/EFSPIntegration/test/integration_test.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python3
+
 from docassemble.base.util import Address, Person, Individual
 from docassemble.AssemblyLine.al_general import ALIndividual
 from ..efm_client import ProxyConnection, ApiResponse

--- a/docassemble/EFSPIntegration/test/temp2.json
+++ b/docassemble/EFSPIntegration/test/temp2.json
@@ -2787,7 +2787,7 @@
             "globalScope": true,
             "typeSubstituted": false
         },
-        "case_type": "5892",
+        "tyler_case_type": "5892",
         "title": "IMPOUNDED ADOPTION",
         "date": "2022-01-25T01:00:00-05:00",
         "participants": {


### PR DESCRIPTION
Makes it possible to do multiple distinct case searches in a single case (such
as a search in the housing and appeals court at the same times), and generally
can be more reliable when combined with review screens and recomputation.

Other misc things:
* makes everything use `tyler_case_type`. Might decide it's a bad name, but it's the important one for now.
* the `filter_codes` helper function, makes it a lot easier to get the right code that you want in not as many lines

Will likely merge quickly, without review, as there's a few other things I need to rebase on this. Feel free to still critique / make comments after it's merged, and I'll address them elsewhere.