### PR TITLE
Adapt to jeff net interviews well

### DIFF
--- a/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
+++ b/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
@@ -933,6 +933,10 @@ fields:
   - You are this party: users[0].is_form_filler
     datatype: yesnoradio
 ---
+if: full_court_info.get("efmType", "ecf") != "ecf"
+code: |
+  users[0].is_form_filler = False
+---
 code: |
   if i > 0:
     users[i].is_form_filler = False

--- a/docassemble/EFSPIntegration/data/questions/login_qs.yml
+++ b/docassemble/EFSPIntegration/data/questions/login_qs.yml
@@ -104,15 +104,17 @@ validation code: |
     password_rules
     validation_error(password_rules.data.get("validationmessage"))
 ---
+if: not can_check_efile or full_court_info.get("efmType", "ecf") != "ecf"
+code: |
+  logged_in_user_is_admin = False
+  logged_in_user_is_global_admin = False
+---
 depends on:
   - tyler_login
   - tyler_login_resp
+if: can_check_efile and full_court_info.get("efmType", "ecf") == "ecf"
 code: |
-  if not can_check_efile:
-    logged_in_user_is_admin = False
-    logged_in_user_is_global_admin = False
-  else:
-    logged_in_user_is_admin, logged_in_user_is_global_admin = get_tyler_roles(proxy_conn, tyler_login_resp.data)
+  logged_in_user_is_admin, logged_in_user_is_global_admin = get_tyler_roles(proxy_conn, tyler_login_resp.data)
 ---
 event: reset_password_screen
 question: |


### PR DESCRIPTION
* Requires [EfileProxyServer 1.0.0rc2](https://github.com/SuffolkLITLab/EfileProxyServer/commit/d37fe0a0710921ad902d92a94e06ef1008bfaeb7)
* The only changes that are needed: we need to ignore form_filer and logged_in stuff if not on ECF, so we can add that.