### PR TITLE
Dastore login

### DIFF
--- a/docassemble/EFSPIntegration/conversions.py
+++ b/docassemble/EFSPIntegration/conversions.py
@@ -697,19 +697,20 @@ def filing_id_and_label(case: Mapping, style="FILING_ID") -> Dict[str, str]:
 
 
 def get_tyler_roles(
-    proxy_conn: ProxyConnection, login_data: Mapping
+    proxy_conn: ProxyConnection, login_data: Mapping, user_details: Optional[Mapping] = None
 ) -> Tuple[bool, bool]:
     """Gets whether or not the user of this interview is a Tyler Admin, and a 'global' admin.
     The global admin means that they are allowed to change specific Global payment methods,
     and can be listed under the 'global server admins' section of the 'efile proxy' settings in the
     DAConfig"""
 
-    if not login_data:
+    if not user_details:
+      if not login_data:
         return False, False
+      user_details = proxy_conn.get_user(
+          login_data.get("TYLER-ID", login_data.get("TYLER_ID"))
+      )
 
-    user_details = proxy_conn.get_user(
-        login_data.get("TYLER-ID", login_data.get("TYLER_ID"))
-    )
     if not user_details.data:
         return False, False
 

--- a/docassemble/EFSPIntegration/conversions.py
+++ b/docassemble/EFSPIntegration/conversions.py
@@ -697,7 +697,7 @@ def filing_id_and_label(case: Mapping, style="FILING_ID") -> Dict[str, str]:
 
 
 def get_tyler_roles(
-    proxy_conn: ProxyConnection, login_data: Mapping, user_details: Optional[Mapping] = None
+    proxy_conn: ProxyConnection, login_data: Mapping, user_details: Optional[ApiResponse] = None
 ) -> Tuple[bool, bool]:
     """Gets whether or not the user of this interview is a Tyler Admin, and a 'global' admin.
     The global admin means that they are allowed to change specific Global payment methods,

--- a/docassemble/EFSPIntegration/data/questions/login_qs.yml
+++ b/docassemble/EFSPIntegration/data/questions/login_qs.yml
@@ -3,6 +3,9 @@ comment: |
   This file requires the following variables:
   * `jurisdiction_id`
 ---
+objects:
+  - da_store: DAStore
+---
 modules:
   - .conversions
   - .interview_logic
@@ -47,6 +50,17 @@ code: |
     else:
       log(word("You are now connected to your e-filing account"), "primary")
   tyler_login = True
+---
+code: |
+  tyler_header_name = f"TYLER-TOKEN-{jurisdiction_id.upper()}"
+  if da_store.defined("EFSP-" + tyler_header_name):
+    proxy_conn.proxy_client.headers[tyler_header_name] = da_store.get("EFSP-" + tyler_header_name)
+    tyler_user = proxy_conn.get_user()
+    if tyler_user.is_ok():
+      my_username = tyler_user.data.get('email')
+      log(word("You are now connected to your e-filing account") + f" ({my_username})", "primary")
+      logged_in_user_is_admin, logged_in_user_is_global_admin = get_tyler_roles(proxy_conn, None, tyler_user)
+      tyler_login = True
 ---
 code: |
   change_resp = proxy_conn.self_change_password(current_password, new_user_password)

--- a/docassemble/EFSPIntegration/efm_client.py
+++ b/docassemble/EFSPIntegration/efm_client.py
@@ -11,6 +11,7 @@ from docassemble.base.util import (
     log,
     Person,
     Individual,
+    DAStore,
     DADateTime,
     as_datetime,
     reconsider,
@@ -182,12 +183,17 @@ class ProxyConnection(EfspConnection):
             tyler_password = temp_efile_config.get("tyler password")
         if jeffnet_key is None:
             jeffnet_key = temp_efile_config.get("jeffnet api token")
-        return super().authenticate_user(
+        resp = super().authenticate_user(
             tyler_email=tyler_email,
             tyler_password=tyler_password,
             jeffnet_key=jeffnet_key,
             jurisdiction=jurisdiction,
         )
+        if resp.is_ok():
+            store = DAStore(encrypted=True)
+            for k, v in resp.data.get("tokens", {}).items():
+                store.set(f"EFSP-{k}", v)
+        return resp
 
     def register_user(
         self,


### PR DESCRIPTION
Use DAStore to store login tokens for Tyler per user, server wide. This lets us make separate interview flows (better for stability and repeated actions than trying to manage things in interview) for managing different aspects of the filing process, like payments and service accounts, and means people don't have to log back in for each of those.

Everything is in, but want to use it a bit more to make sure it works, and maybe do some more manual testing regarding upgrading, so it doesn't break existing interview sessions at all.