### PR TITLE
Show Password checkbox

### DIFF
--- a/docassemble/EFSPIntegration/data/questions/admin_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/admin_interview.yml
@@ -431,7 +431,7 @@ question: |
   Password?
 fields:
   - Password: new_password
-    datatype: VisiblePassword
+    datatype: ALVisiblePassword
 ---
 id: user id
 question: |

--- a/docassemble/EFSPIntegration/data/questions/admin_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/admin_interview.yml
@@ -431,7 +431,7 @@ question: |
   Password?
 fields:
   - Password: new_password
-    datatype: password
+    datatype: VisiblePassword
 ---
 id: user id
 question: |

--- a/docassemble/EFSPIntegration/data/questions/login_qs.yml
+++ b/docassemble/EFSPIntegration/data/questions/login_qs.yml
@@ -29,7 +29,7 @@ subquestion: |
 fields:
   - email/username: my_username
   - password: my_password
-    datatype: VisiblePassword
+    datatype: ALVisiblePassword
     hide if: user_forgot_password
   - I forgot my password: user_forgot_password
     datatype: yesno
@@ -82,9 +82,9 @@ question: |
   New Password?
 fields:
   - New password: new_user_password
-    datatype: VisiblePassword
+    datatype: ALVisiblePassword
   - Confirm new password: confirm_new_password
-    datatype: VisiblePassword
+    datatype: ALVisiblePassword
 validation code: |
   if not new_user_password == confirm_new_password:
     validation_error("Your passwords do not match.", field="confirm_new_password")    
@@ -94,11 +94,11 @@ question: |
   Change password
 fields:
   - Current password: current_password
-    datatype: VisiblePassword
+    datatype: ALVisiblePassword
   - New password: new_user_password
-    datatype: VisiblePassword
+    datatype: ALVisiblePassword
   - Confirm new password: confirm_new_password
-    datatype: VisiblePassword
+    datatype: ALVisiblePassword
 validation code: |
   if not new_user_password == confirm_new_password:
     validation_error(word("Your passwords do not match."), field="confirm_new_password")

--- a/docassemble/EFSPIntegration/data/questions/login_qs.yml
+++ b/docassemble/EFSPIntegration/data/questions/login_qs.yml
@@ -29,7 +29,7 @@ subquestion: |
 fields:
   - email/username: my_username
   - password: my_password
-    datatype: password
+    datatype: VisiblePassword
     hide if: user_forgot_password
   - I forgot my password: user_forgot_password
     datatype: yesno
@@ -82,9 +82,9 @@ question: |
   New Password?
 fields:
   - New password: new_user_password
-    datatype: password
+    datatype: VisiblePassword
   - Confirm new password: confirm_new_password
-    datatype: password
+    datatype: VisiblePassword
 validation code: |
   if not new_user_password == confirm_new_password:
     validation_error("Your passwords do not match.", field="confirm_new_password")    
@@ -94,11 +94,11 @@ question: |
   Change password
 fields:
   - Current password: current_password
-    datatype: password
+    datatype: VisiblePassword
   - New password: new_user_password
-    datatype: password
+    datatype: VisiblePassword
   - Confirm new password: confirm_new_password
-    datatype: password
+    datatype: VisiblePassword
 validation code: |
   if not new_user_password == confirm_new_password:
     validation_error(word("Your passwords do not match."), field="confirm_new_password")
@@ -127,6 +127,8 @@ question: |
   Something went wrong when we tried to reset your password
   % endif
 subquestion: |
+  ${ tyler_reset_password_resp.error_msg + "." if not tyler_reset_password_resp.is_ok() else ""}
+
   You can also [resend your activation email](${ url_ask(
       [{'recompute': ['self_resend_activation','show_activation_resp']}]) }).
 ---
@@ -149,8 +151,6 @@ subquestion: |
   % else:
   Something went wrong when logging you in. We will not be able to e-file your form.  
   % endif
-buttons:
-  - restart
 ---
 ##########
 ## As a result of logging in, we can use defaults. That's why they're in this file.

--- a/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
+++ b/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
@@ -113,7 +113,7 @@ fields:
   - note: |
       ${ password_rules.data.get("validationmessage") }
   - Password: new_password
-    datatype: VisiblePassword
+    datatype: ALVisiblePassword
     validate: proxy_conn.is_valid_password
   - note: |
       ---

--- a/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
+++ b/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
@@ -113,7 +113,7 @@ fields:
   - note: |
       ${ password_rules.data.get("validationmessage") }
   - Password: new_password
-    datatype: password
+    datatype: VisiblePassword
     validate: proxy_conn.is_valid_password
   - note: |
       ---

--- a/docassemble/EFSPIntegration/interview_logic.py
+++ b/docassemble/EFSPIntegration/interview_logic.py
@@ -45,7 +45,7 @@ class EFCaseSearch(DAObject):
 
 _visible_password_js = """
   $(document).on('daPageLoad', function() {
-    $('input[type="VisiblePassword"]').each(function() {
+    $('input[type="ALVisiblePassword"]').each(function() {
       var thisElement = this;
       $(thisElement).attr("type", "password");
       var checkbox_div = $('<div></div>');
@@ -65,9 +65,9 @@ _visible_password_js = """
   });
 """
 
-class VisiblePassword(CustomDataType):
-    name = "VisiblePassword"
-    input_type = "VisiblePassword"
+class ALVisiblePassword(CustomDataType):
+    name = "ALVisiblePassword"
+    input_type = "ALVisiblePassword"
     javascript = _visible_password_js
 
 

--- a/docassemble/EFSPIntegration/interview_logic.py
+++ b/docassemble/EFSPIntegration/interview_logic.py
@@ -6,7 +6,7 @@ package, but for better python tooling support, were moved here.
 from typing import Any, Callable, Dict, List, Tuple, Optional, Iterable, Union
 from datetime import datetime
 
-from docassemble.base.util import DAObject, DAList, log, word
+from docassemble.base.util import CustomDataType, DAObject, DAList, log, word
 from .conversions import parse_case_info, fetch_case_info, chain_xml
 from docassemble.AssemblyLine.al_general import ALPeopleList, ALIndividual
 
@@ -42,6 +42,34 @@ class EFCaseSearch(DAObject):
         if can_file_non_indexed_case:
             lookup_choices.append({"non_indexed_case": str(self.non_indexed_choice)})
         return lookup_choices
+
+_visible_password_js = """
+  $(document).on('daPageLoad', function() {
+    $('input[type="VisiblePassword"]').each(function() {
+      var thisElement = this;
+      $(thisElement).attr("type", "password");
+      var checkbox_div = $('<div></div>');
+      var checkbox_input = $('<input type="checkbox" id="idk-check">');
+      var checkbox_label = $('<label for="idk-check">Show password</label>');
+      $(checkbox_input).on('change', function() {
+        if (this.checked) {
+          $(thisElement).attr('type', 'text');
+        } else {
+          $(thisElement).attr('type', 'password');
+        }
+      })
+      $(thisElement).after(checkbox_div);
+      $(checkbox_div).append(checkbox_input);
+      $(checkbox_div).append(checkbox_label);
+    })
+  });
+"""
+
+class VisiblePassword(CustomDataType):
+    name = "VisiblePassword"
+    input_type = "VisiblePassword"
+    javascript = _visible_password_js
+
 
 
 def address_fields_with_defaults(

--- a/docassemble/EFSPIntegration/interview_logic.py
+++ b/docassemble/EFSPIntegration/interview_logic.py
@@ -50,7 +50,7 @@ _visible_password_js = """
       $(thisElement).attr("type", "password");
       var checkbox_div = $('<div></div>');
       var checkbox_input = $('<input type="checkbox" id="idk-check">');
-      var checkbox_label = $('<label for="idk-check">Show password</label>');
+      var checkbox_label = $('<label for="idk-check" style="margin-left:7px">Show password</label>');
       $(checkbox_input).on('change', function() {
         if (this.checked) {
           $(thisElement).attr('type', 'text');


### PR DESCRIPTION
Adds the ALVisible Password custom datatype, that lets you view your password
when entering it. It doesn't change anything about the datatype on the backend,
just some additional javascript on the frontend (a checkbox to show the
password). Tested with screen reader, properly reads the field, lets you check the box, and then will properly read out the typed in password so far, instead of "Bullet bullet bullet bullet..."

Additionally, shows Tyler's error messages when trying to reset passwords, which
do say if the email exists or not.

Tests pass locally, test server too unstable to actually test anything.