### PR TITLE
Fix unauthencated interview

### DIFF
--- a/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
+++ b/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
@@ -605,11 +605,17 @@ code: |
 generic object: DAObject
 code: |
   x.document_type_filters = []
+---
+generic object: DAObject
+code: |
   x.document_type_default = None
 ---
 generic object: DAObject
 code: |
   x.filing_type_filters = []
+---
+generic object: DAObject
+code: |
   x.filing_type_default = None
 ---
 generic object: DAObject

--- a/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
+++ b/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
@@ -17,6 +17,7 @@ modules:
 ---
 include:
   - docassemble.ALToolbox:phone-number-validation.yml
+  - docassemble.AssemblyLine:assembly_line.yml
 ---
 objects:
   person_to_reg: ALIndividual

--- a/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
+++ b/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
@@ -112,7 +112,7 @@ fields:
   - Phone number: person_to_reg.phone_number
     datatype: al_international_phone
   - note: |
-      ${ password_rules.data.get("validationmessage") }
+      ${ password_rules.get("validationmessage") }
   - Password: new_password
     datatype: ALVisiblePassword
     validate: proxy_conn.is_valid_password
@@ -129,7 +129,11 @@ fields:
       person_to_reg.address_fields()
 ---
 code: |
-  password_rules = proxy_conn.get_password_rules()
+  password_rules_resp = proxy_conn.get_password_rules()
+  if password_rules_resp.is_ok():
+    password_rules = password_rules.data
+  else:
+    password_rules = {}
 ---
 code: |
   resent_activation_resp = proxy_conn.self_resend_activation_email(unauthed_user_email)

--- a/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
+++ b/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
@@ -131,7 +131,7 @@ fields:
 code: |
   password_rules_resp = proxy_conn.get_password_rules()
   if password_rules_resp.is_ok():
-    password_rules = password_rules.data
+    password_rules = password_rules_resp.data
   else:
     password_rules = {}
 ---

--- a/docassemble/EFSPIntegration/py_efsp_client.py
+++ b/docassemble/EFSPIntegration/py_efsp_client.py
@@ -234,10 +234,12 @@ class EfspConnection:
 
     def get_password_rules(self) -> ApiResponse:
         """
-        Password rules are stored in the global court, id 1.
+        Password rules are stored in the global court, id 0.
+
+        TODO: They're in other courts too, including 1. Could they ever be different?
         """
         send = lambda: self.proxy_client.get(
-            self.full_url("codes/courts/1/datafields/GlobalPassword")
+            self.full_url("codes/courts/0/datafields/GlobalPassword")
         )
         return self._call_proxy(send)
 


### PR DESCRIPTION
* password rules are in the 0 court sometimes, not just the 1 court
* can check if password rules in the first place (if not there, assume there aren't any)