### PR TITLE
Integration updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.egg-info/**
 rcfile
 **/.mypy_cache/**
+build/
 
 # Kiln stuff
 alkiln_tests_*

--- a/docassemble/EFSPIntegration/data/questions/unauthenticated_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/unauthenticated_interview.yml
@@ -27,3 +27,4 @@ subquestion: |
       label=disp) }
 
   % endfor
+---

--- a/docassemble/EFSPIntegration/interview_logic.py
+++ b/docassemble/EFSPIntegration/interview_logic.py
@@ -3,7 +3,7 @@ A group of methods that were code blocks in various parts of the EFSP
 package, but for better python tooling support, were moved here.
 """
 
-from typing import Any, Callable, Dict, List, Tuple, Optional, Iterable, Union
+from typing import Any, Callable, Dict, List, Tuple, Optional, Iterable, Union, TypedDict
 from datetime import datetime
 
 from docassemble.base.util import CustomDataType, DAObject, DAList, log, word
@@ -112,10 +112,30 @@ def address_fields_with_defaults(
     return address_fields
 
 
+FieldEntry = TypedDict(
+    'FieldEntry',
+    {
+        "label": str,
+        "field": str,
+        "datatype": str,
+        "rows": int,
+        "help": str,
+        "show if": Union[str, Dict[str, str]],
+        "hide if": str,
+        "input type": str,
+        "default": str,
+        "code": str,
+        "address autocomplete": bool,
+        "choices": Union[List[str], Dict[str, str]],
+        "required": bool
+    },
+    total=False)
+Fields = List[FieldEntry]
+
 def contact_fields_with_defaults(
     proxy_conn, person: ALIndividual, is_admin: bool, can_check_efile: bool
 ):
-    contact_fields = [
+    contact_fields: List[FieldEntry] = [
         {
             "label": word("Mobile number"),
             "field": person.attr_name("mobile_number"),

--- a/docassemble/EFSPIntegration/interview_logic.py
+++ b/docassemble/EFSPIntegration/interview_logic.py
@@ -3,7 +3,17 @@ A group of methods that were code blocks in various parts of the EFSP
 package, but for better python tooling support, were moved here.
 """
 
-from typing import Any, Callable, Dict, List, Tuple, Optional, Iterable, Union, TypedDict
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Tuple,
+    Optional,
+    Iterable,
+    Union,
+    TypedDict,
+)
 from datetime import datetime
 
 from docassemble.base.util import CustomDataType, DAObject, DAList, log, word
@@ -113,7 +123,7 @@ def address_fields_with_defaults(
 
 
 FieldEntry = TypedDict(
-    'FieldEntry',
+    "FieldEntry",
     {
         "label": str,
         "field": str,
@@ -127,10 +137,12 @@ FieldEntry = TypedDict(
         "code": str,
         "address autocomplete": bool,
         "choices": Union[List[str], Dict[str, str]],
-        "required": bool
+        "required": bool,
     },
-    total=False)
+    total=False,
+)
 Fields = List[FieldEntry]
+
 
 def contact_fields_with_defaults(
     proxy_conn, person: ALIndividual, is_admin: bool, can_check_efile: bool

--- a/docassemble/EFSPIntegration/py_efsp_client.py
+++ b/docassemble/EFSPIntegration/py_efsp_client.py
@@ -8,7 +8,6 @@ Doesn't include anything from docassemble, and can be used without having it ins
 
 import re
 import logging
-import isodate
 import requests
 from requests import Response
 from datetime import datetime

--- a/docassemble/EFSPIntegration/test/integration_test.py
+++ b/docassemble/EFSPIntegration/test/integration_test.py
@@ -51,7 +51,9 @@ def mock_person():
 
 
 class TestClass:
-    def __init__(self, proxy_conn, verbose: bool = True, user_email = None, user_password = None):
+    def __init__(
+        self, proxy_conn, verbose: bool = True, user_email=None, user_password=None
+    ):
         self.proxy_conn = proxy_conn
         self.verbose = verbose
         self.user_email = user_email
@@ -69,8 +71,7 @@ class TestClass:
         self.basic_assert(empty_resp)
         assert len(empty_resp.data["tokens"]) == 0
         resp = self.proxy_conn.authenticate_user(
-            tyler_email=self.user_email,
-            tyler_password=self.user_password
+            tyler_email=self.user_email, tyler_password=self.user_password
         )
         self.basic_assert(resp)
 
@@ -94,17 +95,21 @@ class TestClass:
             if "{" in url or "}" in url:
                 continue
             # TODO(brycew): scheduling is broken, /service-contacts/public isn't RESTful
-            if 'scheduling' in url or 'service-contacts/public' in url:
+            if "scheduling" in url or "service-contacts/public" in url:
                 continue
             print(f"visiting {url}")
             send = lambda: self.proxy_conn.proxy_client.get(url)
             resp = self.basic_assert(self.proxy_conn._call_proxy(send)).data
             if isinstance(resp, dict):
                 for url in resp.values():
-                    if isinstance(url, str) and url.startswith('http'):
+                    if isinstance(url, str) and url.startswith("http"):
                         all_urls.append(url)
-                    elif isinstance(url, dict) and ('method' in url and url['method'] == 'GET') and 'url' in url:
-                        all_urls.append(url['url'])
+                    elif (
+                        isinstance(url, dict)
+                        and ("method" in url and url["method"] == "GET")
+                        and "url" in url
+                    ):
+                        all_urls.append(url["url"])
 
     def test_self_user(self):
         print("\n\n### Self user ###\n\n")
@@ -115,9 +120,7 @@ class TestClass:
         )
         bad_spelling = self.basic_assert(self.proxy_conn.get_user())
         assert bad_spelling.data["middleName"] == "Stephen"
-        self.basic_assert(
-            self.proxy_conn.self_update_user(middle_name="Steven")
-        )
+        self.basic_assert(self.proxy_conn.self_update_user(middle_name="Steven"))
 
         # Password stuff
         current_password = self.user_password
@@ -464,7 +467,9 @@ class TestClass:
         self.basic_assert(self.proxy_conn.get_court("adams"))
         self.basic_assert(self.proxy_conn.get_datafield("adams", "GlobalPassword"))
         self.basic_assert(self.proxy_conn.get_disclaimers("adams"))
-        categories = self.basic_assert(self.proxy_conn.get_case_categories("adams")).data
+        categories = self.basic_assert(
+            self.proxy_conn.get_case_categories("adams")
+        ).data
         for idx, cat in enumerate(categories):
             if idx > 5:
                 continue
@@ -500,7 +505,9 @@ def main(*, base_url, api_key, user_email=None, user_password=None):
         url=base_url, api_key=api_key, default_jurisdiction="illinois"
     )
     proxy_conn.set_verbose_logging(False)
-    tc = TestClass(proxy_conn, verbose=True, user_email=user_email, user_password=user_password)
+    tc = TestClass(
+        proxy_conn, verbose=True, user_email=user_email, user_password=user_password
+    )
     tc.test_authenticate()
     tc.test_hateos()
     tc.test_self_user()

--- a/docassemble/EFSPIntegration/test/integration_test.py
+++ b/docassemble/EFSPIntegration/test/integration_test.py
@@ -528,4 +528,4 @@ def main(*, base_url, api_key, user_email=None, user_password=None):
 
 
 if __name__ == "__main__":
-    main(api_key=os.getenv("PROXY_API_KEY"))
+    main(base_url=None, api_key=os.getenv("PROXY_API_KEY"))

--- a/docassemble/EFSPIntegration/test/integration_test.py
+++ b/docassemble/EFSPIntegration/test/integration_test.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python3
 
-from ..py_efsp_client import EfspConnection, ApiResponse
-import sys
+from docassemble.EFSPIntegration.py_efsp_client import EfspConnection, ApiResponse
 import subprocess
 import json
 import os

--- a/docassemble/EFSPIntegration/test/opening_affidavit_adams.json
+++ b/docassemble/EFSPIntegration/test/opening_affidavit_adams.json
@@ -1,0 +1,1473 @@
+{
+  "al_session_store_default_filename": "docassemble.AssemblyLine:al_saved_sessions_store.yml",
+  "al_sessions_interview_title": {
+    "_class": "docassemble.base.util.DALazyTemplate",
+    "instanceName": "al_sessions_interview_title"
+  },
+  "al_enable_incomplete_downloads": true,
+  "package_version_number": "1.2.2",
+  "al_version": "AL-2.21.0",
+  "AL_ORGANIZATION_TITLE": "Suffolk Lit Lab dev",
+  "AL_ORGANIZATION_HOMEPAGE": "https://courtformsonline.org",
+  "al_logo": {
+    "_class": "docassemble.base.util.DAStaticFile",
+    "instanceName": "al_logo",
+    "extension": "png",
+    "mimetype": "image/png",
+    "package": "docassemble.AssemblyLine",
+    "filename": "ma_logo.png",
+    "alt_text": "Assembly Line Logo"
+  },
+  "feedback_form": "docassemble.AssemblyLine:feedback.yml",
+  "package_name": "docassemble.EFSPIntegration",
+  "github_repo_name": "docassemble-EFSPIntegration",
+  "github_user": "suffolklitlab",
+  "jurisdiction_id": "illinois",
+  "welcome": true,
+  "proxy_conn": null,
+  "da_store": {
+    "_class": "docassemble.base.util.DAStore",
+    "instanceName": "da_store"
+  },
+  "tyler_header_name": "TYLER-TOKEN-ILLINOIS",
+  "tyler_user": null,
+  "my_username": "bryce.steven.willey+faketylerprose@gmail.com",
+  "continue_stored_login": true,
+  "logged_in_user_is_admin": false,
+  "logged_in_user_is_global_admin": false,
+  "tyler_login": true,
+  "trial_court_map": {
+    "TSUPCRT": "  Supreme Court of Illinois",
+    "TAC1": " Appellate Court \u2013 1st District",
+    "TAC2": " Appellate Court \u2013 2nd District",
+    "TAC3": " Appellate Court \u2013 3rd District",
+    "TAC4": " Appellate Court \u2013 4th District",
+    "TAC5": " Appellate Court \u2013 5th District",
+    "ardc": "ARDC Clerk's Office",
+    "adams": "Adams County",
+    "alexander": "Alexander County",
+    "bond": "Bond County",
+    "boone": "Boone County",
+    "brown": "Brown County",
+    "bureau": "Bureau County",
+    "calhoun": "Calhoun County",
+    "carroll": "Carroll County",
+    "cass": "Cass County",
+    "champaign": "Champaign County",
+    "christian": "Christian County",
+    "clark": "Clark County",
+    "clay": "Clay County",
+    "clinton": "Clinton County",
+    "coles": "Coles County",
+    "cook:chd1": "Cook County - Chancery - District 1 - Chicago",
+    "cook:cd1": "Cook County - County Division - District 1 - Chicago",
+    "cook:crcbc": "Cook County - Criminal - District 1 - Central Bond Court",
+    "cook:crd1": "Cook County - Criminal - District 1 - Chicago",
+    "cook:crb2": "Cook County - Criminal - District 1 - Criminal Branch 2",
+    "cook:crb23": "Cook County - Criminal - District 1 - Criminal Branch 23",
+    "cook:crb29": "Cook County - Criminal - District 1 - Criminal Branch 29",
+    "cook:crb34": "Cook County - Criminal - District 1 - Criminal Branch 34",
+    "cook:crb35": "Cook County - Criminal - District 1 - Criminal Branch 35",
+    "cook:crb38": "Cook County - Criminal - District 1 - Criminal Branch 38",
+    "cook:crb42": "Cook County - Criminal - District 1 - Criminal Branch 42",
+    "cook:crb43": "Cook County - Criminal - District 1 - Criminal Branch 43",
+    "cook:crb44": "Cook County - Criminal - District 1 - Criminal Branch 44",
+    "cook:crb46": "Cook County - Criminal - District 1 - Criminal Branch 46",
+    "cook:crb48": "Cook County - Criminal - District 1 - Criminal Branch 48",
+    "cook:crb50": "Cook County - Criminal - District 1 - Criminal Branch 50",
+    "cook:crb60": "Cook County - Criminal - District 1 - Criminal Branch 60",
+    "cook:crb61": "Cook County - Criminal - District 1 - Criminal Branch 61",
+    "cook:crb62": "Cook County - Criminal - District 1 - Criminal Branch 62",
+    "cook:crb63": "Cook County - Criminal - District 1 - Criminal Branch 63",
+    "cook:crb64": "Cook County - Criminal - District 1 - Criminal Branch 64",
+    "cook:crb66": "Cook County - Criminal - District 1 - Criminal Branch 66",
+    "cook:crb7": "Cook County - Criminal - District 1 - Criminal Branch 7",
+    "cook:crb9": "Cook County - Criminal - District 1 - Criminal Branch 9",
+    "cook:crb95": "Cook County - Criminal - District 1 - Criminal Branch 95",
+    "cook:crb98": "Cook County - Criminal - District 1 - Criminal Branch 98",
+    "cook:crd1cdpt": "Cook County - Criminal - District 1 - Criminal Department",
+    "cook:crd1cd": "Cook County - Criminal - District 1 - Criminal Division",
+    "cook:crd2": "Cook County - Criminal - District 2 - Skokie",
+    "cook:crd3": "Cook County - Criminal - District 3 - Rolling Meadows",
+    "cook:crd4": "Cook County - Criminal - District 4 - Maywood",
+    "cook:crd5": "Cook County - Criminal - District 5 - Bridgeview",
+    "cook:crd6": "Cook County - Criminal - District 6 - Markham",
+    "cook:crb": "Cook County - Criminal Bureau",
+    "cook:dr1": "Cook County - Domestic Relations - District 1 - Chicago",
+    "cook:dr2": "Cook County - Domestic Relations - District 2 - Skokie",
+    "cook:dr3": "Cook County - Domestic Relations - District 3 - Rolling Meadows",
+    "cook:dr4": "Cook County - Domestic Relations - District 4 - Maywood",
+    "cook:dr5": "Cook County - Domestic Relations - District 5 - Bridgeview",
+    "cook:dr6": "Cook County - Domestic Relations - District 6 - Markham",
+    "cook:jjcp": "Cook County - Juvenile Justice/Child Protection",
+    "cook:jjcpd6": "Cook County - Juvenile Justice/Child Protection - District 6 - Markham",
+    "cook:law1": "Cook County - Law - District 1 - Chicago",
+    "cook:law2": "Cook County - Law - District 2 - Skokie",
+    "cook:law3": "Cook County - Law - District 3 - Rolling Meadows",
+    "cook:law4": "Cook County - Law - District 4 - Maywood",
+    "cook:law5": "Cook County - Law - District 5 - Bridgeview",
+    "cook:law6": "Cook County - Law - District 6 - Markham",
+    "cook:cvd1": "Cook County - Municipal Civil - District 1 - Chicago",
+    "cook:cvd2": "Cook County - Municipal Civil - District 2 - Skokie",
+    "cook:cvd3": "Cook County - Municipal Civil - District 3 - Rolling Meadows",
+    "cook:cvd4": "Cook County - Municipal Civil - District 4 - Maywood",
+    "cook:cvd5": "Cook County - Municipal Civil - District 5 - Bridgeview",
+    "cook:cvd6": "Cook County - Municipal Civil - District 6 - Markham",
+    "cook:pr1": "Cook County - Probate  - District 1 - Chicago",
+    "crawford": "Crawford County",
+    "cumberland": "Cumberland County",
+    "dewitt": "De Witt County",
+    "dekalb": "DeKalb County",
+    "douglas": "Douglas County",
+    "dupageinteg": "DuPage County",
+    "edgar": "Edgar County",
+    "edwards": "Edwards County",
+    "effingham": "Effingham County",
+    "fayette": "Fayette County",
+    "ford": "Ford County",
+    "franklin": "Franklin County",
+    "fulton": "Fulton County",
+    "gallatin": "Gallatin County",
+    "goodin": "Goodin County",
+    "greene": "Greene County",
+    "grundy": "Grundy County",
+    "hamilton": "Hamilton County",
+    "hancock": "Hancock County",
+    "hardin": "Hardin County",
+    "henderson": "Henderson County",
+    "henry": "Henry County",
+    "iroquois": "Iroquois County",
+    "jackson": "Jackson County",
+    "jasper": "Jasper County",
+    "jefferson": "Jefferson County",
+    "jersey": "Jersey County",
+    "jodaviess": "Jo Daviess County",
+    "johnson": "Johnson County",
+    "kane": "Kane County",
+    "kankakee": "Kankakee County",
+    "kendall": "Kendall County",
+    "knox": "Knox County",
+    "lasalle": "LaSalle County",
+    "lake": "Lake County",
+    "lawrence": "Lawrence County",
+    "lee": "Lee County",
+    "livingston": "Livingston County",
+    "logan": "Logan County",
+    "macon": "Macon County",
+    "macoupin": "Macoupin County",
+    "madison": "Madison County",
+    "marion": "Marion County",
+    "marshall": "Marshall County",
+    "mason": "Mason County",
+    "massac": "Massac County",
+    "mcdonough": "McDonough County",
+    "mchenry": "McHenry County",
+    "mclean": "McLean County",
+    "menard": "Menard County",
+    "mercer": "Mercer County",
+    "monroe": "Monroe County",
+    "montgomery": "Montgomery County",
+    "morgan": "Morgan County",
+    "moultrie": "Moultrie County",
+    "ogle": "Ogle County",
+    "peoriacr": "Peoria CR",
+    "peoriacs": "Peoria CS",
+    "peoria": "Peoria County",
+    "peoriatr": "Peoria TR",
+    "perry": "Perry County",
+    "piatt": "Piatt County",
+    "pike": "Pike County",
+    "pope": "Pope County",
+    "pulaski": "Pulaski County",
+    "putnam": "Putnam County",
+    "randolph": "Randolph County",
+    "richland": "Richland County",
+    "rockisland": "Rock Island County",
+    "saline": "Saline County",
+    "sangamon": "Sangamon County",
+    "schuyler": "Schuyler County",
+    "scott": "Scott County",
+    "shelby": "Shelby County",
+    "stclair": "St. Clair County",
+    "stark": "Stark County",
+    "stephenson": "Stephenson County",
+    "tazewell": "Tazewell County",
+    "tazewell:tr": "Tazewell County - Traffic",
+    "union": "Union County",
+    "vermilion": "Vermilion County",
+    "wabash": "Wabash County",
+    "warren": "Warren County",
+    "washington": "Washington County",
+    "wayne": "Wayne County",
+    "white": "White County",
+    "whiteside": "Whiteside County",
+    "will": "Will County",
+    "williamson": "Williamson County",
+    "winnebago": "Winnebago County",
+    "woodford": "Woodford County",
+    "zdevcook:chd": "Z - Clarity Dev - Cook - Chancery",
+    "zdevcook:chd1": "Z - Clarity Dev - Cook - Chancery  - District 1 - Chicago",
+    "zdevcook:cvd": "Z - Clarity Dev - Cook - Civil Division",
+    "zdevcook:cvd1": "Z - Clarity Dev - Cook - Civil Division - District 1",
+    "zdevcook:cvd2": "Z - Clarity Dev - Cook - Civil Division - District 2",
+    "zdevcook:cvd3": "Z - Clarity Dev - Cook - Civil Division - District 3",
+    "zdevcook:cvd4": "Z - Clarity Dev - Cook - Civil Division - District 4",
+    "zdevcook:cvd5": "Z - Clarity Dev - Cook - Civil Division - District 5",
+    "zdevcook:cvd6": "Z - Clarity Dev - Cook - Civil Division - District 6",
+    "zdevcook:crdm": "Z - Clarity Dev - Cook - Criminal",
+    "zdevcook:crdm1": "Z - Clarity Dev - Cook - Criminal  - District 1 - Chicago",
+    "zdevcook:crdm2": "Z - Clarity Dev - Cook - Criminal  - District 2 - Skokie",
+    "zdevcook:crdm3": "Z - Clarity Dev - Cook - Criminal  - District 3 - Rolling Meadows",
+    "zdevcook:crdm4": "Z - Clarity Dev - Cook - Criminal  - District 4 - Maywood",
+    "zdevcook:crdm5": "Z - Clarity Dev - Cook - Criminal  - District 5 - Bridgeview",
+    "zdevcook:crdm6": "Z - Clarity Dev - Cook - Criminal  - District 6 - Markham",
+    "zdevcook:dr": "Z - Clarity Dev - Cook - Domestic Relations",
+    "zdevcook:dr1": "Z - Clarity Dev - Cook - Domestic Relations - District 1 - Chicago",
+    "zdevcook:dr2": "Z - Clarity Dev - Cook - Domestic Relations - District 2 - Skokie",
+    "zdevcook:dr3": "Z - Clarity Dev - Cook - Domestic Relations - District 3 - Rolling Meadows",
+    "zdevcook:dr4": "Z - Clarity Dev - Cook - Domestic Relations - District 4 - Maywood",
+    "zdevcook:dr5": "Z - Clarity Dev - Cook - Domestic Relations - District 5 - Bridgeview",
+    "zdevcook:dr6": "Z - Clarity Dev - Cook - Domestic Relations - District 6 - Markham",
+    "zdevcook:dv": "Z - Clarity Dev - Cook - Domestic Violence",
+    "zdevcook:dv1": "Z - Clarity Dev - Cook - Domestic Violence  - District 1 - Chicago",
+    "zdevcook:dv2": "Z - Clarity Dev - Cook - Domestic Violence  - District 2 - Skokie",
+    "zdevcook:dv3": "Z - Clarity Dev - Cook - Domestic Violence  - District 3 - Rolling Meadows",
+    "zdevcook:dv4": "Z - Clarity Dev - Cook - Domestic Violence  - District 4 - Maywood",
+    "zdevcook:dv5": "Z - Clarity Dev - Cook - Domestic Violence  - District 5 - Bridgeview",
+    "zdevcook:dv6": "Z - Clarity Dev - Cook - Domestic Violence  - District 6 - Markham",
+    "zdevcook:jd": "Z - Clarity Dev - Cook - Juvenile",
+    "zdevcook:jddcfs": "Z - Clarity Dev - Cook - Juvenile  - Dept of CFS",
+    "zdevcook:jdjd": "Z - Clarity Dev - Cook - Juvenile  - Justice ",
+    "zdevcook:law": "Z - Clarity Dev - Cook - Law ",
+    "zdevcook:law1": "Z - Clarity Dev - Cook - Law  - District 1 - Chicago",
+    "zdevcook:law2": "Z - Clarity Dev - Cook - Law  - District 2 - Skokie",
+    "zdevcook:law3": "Z - Clarity Dev - Cook - Law  - District 3 - Rolling Meadows",
+    "zdevcook:law4": "Z - Clarity Dev - Cook - Law  - District 4 - Maywood",
+    "zdevcook:law5": "Z - Clarity Dev - Cook - Law  - District 5 - Bridgeview",
+    "zdevcook:law6": "Z - Clarity Dev - Cook - Law  - District 6 - Markham",
+    "zdevcook:pr": "Z - Clarity Dev - Cook - Probate Division",
+    "zdevcook:pr1": "Z - Clarity Dev - Cook - Probate Division - District 1",
+    "ClarityDev": "Z - Clarity Dev Node",
+    "ClarityLocal": "Z - Clarity Local Node",
+    "ClarityStage": "Z - Clarity Stage Node",
+    "mp": "z - MP",
+    "configtest1": "z - Standards 3 Test 1",
+    "configtest2": "z - Standards 3 Test 2",
+    "temptest": "z - Test",
+    "DAC1": "zDEV - 1st District Appellate Court",
+    "DAC2": "zDEV - 2nd District Appellate Court",
+    "DAC3": "zDEV - 3rd District Appellate Court",
+    "DAC4": "zDEV - 4th District Appellate Court",
+    "DAC5": "zDEV - 5th District Appellate Court",
+    "DSUPCRT": "zDEV - Supreme Court of Illinois",
+    "aoictest": "zz - AOIC Testing",
+    "caliber": "zzz - Caliber",
+    "equivant": "zzz - Equivant",
+    "henderson2": "zzz - Henderson County",
+    "jano": "zzz - JANO",
+    "jano2": "zzz - JANO2",
+    "JSYS": "zzz - Justice Systems",
+    "ijustice1": "zzz - Justice Systems 1",
+    "REA": "zzz - REA",
+    "ResearchIL": "zzz - REA ResearchIL",
+    "reaknox 2": "zzz - REA-KNOX  2",
+    "TR-DAC1": "zzz - TR-DAC1",
+    "TR-DAC2": "zzz - TR-DAC2",
+    "TR-DAC3": "zzz - TR-DAC3",
+    "TR-DAC4": "zzz - TR-DAC4",
+    "TR-DAC5": "zzz - TR-DAC5",
+    "TR-SC": "zzz - TR-SC",
+    "thomsonreuters": "zzz - Thomson Reuters",
+    "ijustice": "zzz - iJustice",
+    "journal:lake": "zzz-Journal"
+  },
+  "trial_court": "adams",
+  "court_id": "adams",
+  "efile_setup": true,
+  "user_wants_efile": true,
+  "can_check_efile": true,
+  "filing_interview_initial_or_existing": "initial_document",
+  "is_initial_filing": true,
+  "is_nonindexed_filing": false,
+  "needs_all_info": true,
+  "timing": "Initial",
+  "case_category_options": [
+    ["105721", "Family"],
+    ["105722", "Law: Damages over $50,000"],
+    ["183527", "Law Magistrate: Damages over $10,000 up to $50,000"],
+    ["190919", "Dissolution (Divorce) with Children"],
+    ["190920", "Dissolution (Divorce) without Children"],
+    ["190921", "Eviction"],
+    ["190922", "Foreclosure"],
+    ["190923", "Governmental Corporation"],
+    ["190924", "Guardianship"],
+    ["190925", "Miscellaneous Criminal"],
+    ["6189", "Chancery"],
+    ["6191", "Eminent Domain"],
+    ["6194", "Mental Health"],
+    ["6195", "Miscellaneous Remedy"],
+    ["6196", "Municipal Corporation"],
+    ["6198", "Small Claims"],
+    ["6199", "Tax"],
+    ["7062", "Order of Protection"],
+    ["7306", "Adoption"],
+    ["7420", "Probate"]
+  ],
+  "efile_case_category_filters": [],
+  "efile_case_category_default": null,
+  "efile_case_type_filters": [],
+  "efile_case_type_default": null,
+  "efile_case_category_filtered_options": [
+    ["105721", "Family"],
+    ["105722", "Law: Damages over $50,000"],
+    ["183527", "Law Magistrate: Damages over $10,000 up to $50,000"],
+    ["190919", "Dissolution (Divorce) with Children"],
+    ["190920", "Dissolution (Divorce) without Children"],
+    ["190921", "Eviction"],
+    ["190922", "Foreclosure"],
+    ["190923", "Governmental Corporation"],
+    ["190924", "Guardianship"],
+    ["190925", "Miscellaneous Criminal"],
+    ["6189", "Chancery"],
+    ["6191", "Eminent Domain"],
+    ["6194", "Mental Health"],
+    ["6195", "Miscellaneous Remedy"],
+    ["6196", "Municipal Corporation"],
+    ["6198", "Small Claims"],
+    ["6199", "Tax"],
+    ["7062", "Order of Protection"],
+    ["7306", "Adoption"],
+    ["7420", "Probate"]
+  ],
+  "user_chosen_case_category": "6198",
+  "efile_case_category": "6198",
+  "case_type_options": [
+    ["141997", "Change of Venue - Small Claims"],
+    ["183541", "Contract ($2,500.01 to $10K)"],
+    ["183542", "Contract (Up to $2,500)"],
+    ["183571", "Tort - Money Damages ($2,500.01 to $10K)"],
+    ["183573", "Tort - Money Damages (Up to $2,500)"]
+  ],
+  "efile_case_filtered_options": [
+    ["141997", "Change of Venue - Small Claims"],
+    ["183541", "Contract ($2,500.01 to $10K)"],
+    ["183542", "Contract (Up to $2,500)"],
+    ["183571", "Tort - Money Damages ($2,500.01 to $10K)"],
+    ["183573", "Tort - Money Damages (Up to $2,500)"]
+  ],
+  "user_chosen_case_type": "183541",
+  "efile_case_type": "183541",
+  "case_subtype_options": [],
+  "case_subtype_map": {},
+  "filing_attorney_required_datafield": {
+    "code": "FilingFilingAttorneyView",
+    "name": "Filing window: Filing Attorney Selection",
+    "isvisible": true,
+    "isrequired": false,
+    "helptext": "",
+    "ghosttext": "",
+    "contextualhelpdata": "",
+    "validationmessage": "",
+    "regularexpression": null,
+    "defaultvalueexpression": "",
+    "isreadonly": "False",
+    "location": "adams"
+  },
+  "tyler_filing_attorney_options": [],
+  "tyler_filing_attorney_map": {},
+  "tyler_filing_attorney": null,
+  "interview_metadata": {
+    "_class": "docassemble.base.util.DADict",
+    "instanceName": "interview_metadata",
+    "elements": {},
+    "auto_gather": false,
+    "ask_number": false,
+    "minimum_number": null,
+    "object_type": { "_class": "type", "name": "docassemble.base.util.DADict" },
+    "object_type_parameters": { "auto_gather": false, "gathered": true },
+    "complete_attribute": null,
+    "ask_object_type": false,
+    "gathered": true
+  },
+  "first_form": {},
+  "plaintiff_defendant_help_template": {
+    "_class": "docassemble.base.util.DALazyTemplate",
+    "instanceName": "plaintiff_defendant_help_template"
+  },
+  "user_ask_role": "plaintiff",
+  "user_role": "plaintiff",
+  "al_form_type": "starts_case",
+  "user_started_case": true,
+  "users": {
+    "_class": "docassemble.AssemblyLine.al_general.ALPeopleList",
+    "instanceName": "users",
+    "elements": [
+      {
+        "_class": "docassemble.AssemblyLine.al_general.ALIndividual",
+        "instanceName": "users[0]",
+        "name": {
+          "_class": "docassemble.base.util.IndividualName",
+          "instanceName": "users[0].name",
+          "uses_parts": true,
+          "first": "Bryce",
+          "middle": "",
+          "last": "Willey"
+        },
+        "address": {
+          "_class": "docassemble.AssemblyLine.al_general.ALAddress",
+          "instanceName": "users[0].address",
+          "location": {
+            "_class": "docassemble.base.util.LatitudeLongitude",
+            "instanceName": "users[0].address.location",
+            "gathered": false,
+            "known": false
+          },
+          "_geocoded": false,
+          "geolocated": false,
+          "city_only": false
+        },
+        "location": {
+          "_class": "docassemble.base.util.LatitudeLongitude",
+          "instanceName": "users[0].location",
+          "gathered": false,
+          "known": false
+        },
+        "previous_addresses": {
+          "_class": "docassemble.AssemblyLine.al_general.ALAddressList",
+          "instanceName": "users[0].previous_addresses",
+          "elements": [],
+          "auto_gather": true,
+          "ask_number": false,
+          "minimum_number": null,
+          "object_type": {
+            "_class": "type",
+            "name": "docassemble.AssemblyLine.al_general.ALAddress"
+          },
+          "object_type_parameters": {},
+          "complete_attribute": null,
+          "ask_object_type": false
+        },
+        "other_addresses": {
+          "_class": "docassemble.AssemblyLine.al_general.ALAddressList",
+          "instanceName": "users[0].other_addresses",
+          "elements": [],
+          "auto_gather": true,
+          "ask_number": false,
+          "minimum_number": null,
+          "object_type": {
+            "_class": "type",
+            "name": "docassemble.AssemblyLine.al_general.ALAddress"
+          },
+          "object_type_parameters": {},
+          "complete_attribute": null,
+          "ask_object_type": false
+        },
+        "mailing_address": {
+          "_class": "docassemble.AssemblyLine.al_general.ALAddress",
+          "instanceName": "users[0].mailing_address",
+          "location": {
+            "_class": "docassemble.base.util.LatitudeLongitude",
+            "instanceName": "users[0].mailing_address.location",
+            "gathered": false,
+            "known": false
+          },
+          "_geocoded": false,
+          "geolocated": false,
+          "city_only": false
+        },
+        "service_address": {
+          "_class": "docassemble.AssemblyLine.al_general.ALAddress",
+          "instanceName": "users[0].service_address",
+          "location": {
+            "_class": "docassemble.base.util.LatitudeLongitude",
+            "instanceName": "users[0].service_address.location",
+            "gathered": false,
+            "known": false
+          },
+          "_geocoded": false,
+          "geolocated": false,
+          "city_only": false
+        },
+        "previous_names": {
+          "_class": "docassemble.AssemblyLine.al_general.ALNameList",
+          "instanceName": "users[0].previous_names",
+          "elements": [],
+          "auto_gather": true,
+          "ask_number": false,
+          "minimum_number": null,
+          "object_type": {
+            "_class": "type",
+            "name": "docassemble.base.util.IndividualName"
+          },
+          "object_type_parameters": {},
+          "complete_attribute": null,
+          "ask_object_type": false
+        },
+        "aliases": {
+          "_class": "docassemble.AssemblyLine.al_general.ALNameList",
+          "instanceName": "users[0].aliases",
+          "elements": [],
+          "auto_gather": true,
+          "ask_number": false,
+          "minimum_number": null,
+          "object_type": {
+            "_class": "type",
+            "name": "docassemble.base.util.IndividualName"
+          },
+          "object_type_parameters": {},
+          "complete_attribute": null,
+          "ask_object_type": false
+        },
+        "preferred_name": {
+          "_class": "docassemble.base.util.IndividualName",
+          "instanceName": "users[0].preferred_name",
+          "uses_parts": true
+        },
+        "person_type_label": {
+          "_class": "docassemble.base.util.DALazyTemplate",
+          "instanceName": "users[0].person_type_label"
+        },
+        "individual_choice_label": {
+          "_class": "docassemble.base.util.DALazyTemplate",
+          "instanceName": "users[0].individual_choice_label"
+        },
+        "business_choice_label": {
+          "_class": "docassemble.base.util.DALazyTemplate",
+          "instanceName": "users[0].business_choice_label"
+        },
+        "first_name_label": {
+          "_class": "docassemble.base.util.DALazyTemplate",
+          "instanceName": "users[0].first_name_label"
+        },
+        "middle_name_label": {
+          "_class": "docassemble.base.util.DALazyTemplate",
+          "instanceName": "users[0].middle_name_label"
+        },
+        "last_name_label": {
+          "_class": "docassemble.base.util.DALazyTemplate",
+          "instanceName": "users[0].last_name_label"
+        },
+        "business_name_label": {
+          "_class": "docassemble.base.util.DALazyTemplate",
+          "instanceName": "users[0].business_name_label"
+        },
+        "person_type": "ALIndividual",
+        "is_form_filler": false,
+        "email": "bryce.steven.willey+faketylerprose@gmail.com",
+        "party_type": "20646",
+        "is_new": true,
+        "attorney_adding_opts": {
+          "_class": "docassemble.base.util.DADict",
+          "instanceName": "users[0].attorney_adding_opts",
+          "elements": {},
+          "auto_gather": false,
+          "ask_number": false,
+          "minimum_number": null,
+          "object_type": null,
+          "object_type_parameters": {},
+          "complete_attribute": null,
+          "ask_object_type": false,
+          "gathered": true
+        },
+        "attorney_ids": {
+          "_class": "docassemble.base.util.DAList",
+          "instanceName": "users[0].attorney_ids",
+          "elements": [],
+          "auto_gather": true,
+          "ask_number": false,
+          "minimum_number": null,
+          "there_are_any": false,
+          "gathered": true,
+          "revisit": true,
+          "object_type": null,
+          "object_type_parameters": {},
+          "complete_attribute": null,
+          "ask_object_type": false
+        },
+        "complete": true
+      }
+    ],
+    "auto_gather": true,
+    "ask_number": false,
+    "minimum_number": null,
+    "object_type": {
+      "_class": "type",
+      "name": "docassemble.AssemblyLine.al_general.ALIndividual"
+    },
+    "object_type_parameters": {},
+    "complete_attribute": "complete",
+    "ask_object_type": false,
+    "there_are_any": true,
+    "there_is_another": false,
+    "gathered": true,
+    "revisit": true
+  },
+  "party_type_new_options": [
+    ["20646", "Plaintiff/Petitioner"],
+    ["20641", "Defendant/Respondent"]
+  ],
+  "plaintiff": "20646",
+  "petitioner": "20646",
+  "other_parties": {
+    "_class": "docassemble.AssemblyLine.al_general.ALPeopleList",
+    "instanceName": "other_parties",
+    "elements": [
+      {
+        "_class": "docassemble.AssemblyLine.al_general.ALIndividual",
+        "instanceName": "other_parties[0]",
+        "name": {
+          "_class": "docassemble.base.util.IndividualName",
+          "instanceName": "other_parties[0].name",
+          "uses_parts": true,
+          "first": "Bob",
+          "middle": "",
+          "last": "Bad"
+        },
+        "address": {
+          "_class": "docassemble.AssemblyLine.al_general.ALAddress",
+          "instanceName": "other_parties[0].address",
+          "location": {
+            "_class": "docassemble.base.util.LatitudeLongitude",
+            "instanceName": "other_parties[0].address.location",
+            "gathered": false,
+            "known": false
+          },
+          "_geocoded": false,
+          "geolocated": false,
+          "city_only": false
+        },
+        "location": {
+          "_class": "docassemble.base.util.LatitudeLongitude",
+          "instanceName": "other_parties[0].location",
+          "gathered": false,
+          "known": false
+        },
+        "previous_addresses": {
+          "_class": "docassemble.AssemblyLine.al_general.ALAddressList",
+          "instanceName": "other_parties[0].previous_addresses",
+          "elements": [],
+          "auto_gather": true,
+          "ask_number": false,
+          "minimum_number": null,
+          "object_type": {
+            "_class": "type",
+            "name": "docassemble.AssemblyLine.al_general.ALAddress"
+          },
+          "object_type_parameters": {},
+          "complete_attribute": null,
+          "ask_object_type": false
+        },
+        "other_addresses": {
+          "_class": "docassemble.AssemblyLine.al_general.ALAddressList",
+          "instanceName": "other_parties[0].other_addresses",
+          "elements": [],
+          "auto_gather": true,
+          "ask_number": false,
+          "minimum_number": null,
+          "object_type": {
+            "_class": "type",
+            "name": "docassemble.AssemblyLine.al_general.ALAddress"
+          },
+          "object_type_parameters": {},
+          "complete_attribute": null,
+          "ask_object_type": false
+        },
+        "mailing_address": {
+          "_class": "docassemble.AssemblyLine.al_general.ALAddress",
+          "instanceName": "other_parties[0].mailing_address",
+          "location": {
+            "_class": "docassemble.base.util.LatitudeLongitude",
+            "instanceName": "other_parties[0].mailing_address.location",
+            "gathered": false,
+            "known": false
+          },
+          "_geocoded": false,
+          "geolocated": false,
+          "city_only": false
+        },
+        "service_address": {
+          "_class": "docassemble.AssemblyLine.al_general.ALAddress",
+          "instanceName": "other_parties[0].service_address",
+          "location": {
+            "_class": "docassemble.base.util.LatitudeLongitude",
+            "instanceName": "other_parties[0].service_address.location",
+            "gathered": false,
+            "known": false
+          },
+          "_geocoded": false,
+          "geolocated": false,
+          "city_only": false
+        },
+        "previous_names": {
+          "_class": "docassemble.AssemblyLine.al_general.ALNameList",
+          "instanceName": "other_parties[0].previous_names",
+          "elements": [],
+          "auto_gather": true,
+          "ask_number": false,
+          "minimum_number": null,
+          "object_type": {
+            "_class": "type",
+            "name": "docassemble.base.util.IndividualName"
+          },
+          "object_type_parameters": {},
+          "complete_attribute": null,
+          "ask_object_type": false
+        },
+        "aliases": {
+          "_class": "docassemble.AssemblyLine.al_general.ALNameList",
+          "instanceName": "other_parties[0].aliases",
+          "elements": [],
+          "auto_gather": true,
+          "ask_number": false,
+          "minimum_number": null,
+          "object_type": {
+            "_class": "type",
+            "name": "docassemble.base.util.IndividualName"
+          },
+          "object_type_parameters": {},
+          "complete_attribute": null,
+          "ask_object_type": false
+        },
+        "preferred_name": {
+          "_class": "docassemble.base.util.IndividualName",
+          "instanceName": "other_parties[0].preferred_name",
+          "uses_parts": true
+        },
+        "person_type_label": {
+          "_class": "docassemble.base.util.DALazyTemplate",
+          "instanceName": "other_parties[0].person_type_label"
+        },
+        "individual_choice_label": {
+          "_class": "docassemble.base.util.DALazyTemplate",
+          "instanceName": "other_parties[0].individual_choice_label"
+        },
+        "business_choice_label": {
+          "_class": "docassemble.base.util.DALazyTemplate",
+          "instanceName": "other_parties[0].business_choice_label"
+        },
+        "first_name_label": {
+          "_class": "docassemble.base.util.DALazyTemplate",
+          "instanceName": "other_parties[0].first_name_label"
+        },
+        "middle_name_label": {
+          "_class": "docassemble.base.util.DALazyTemplate",
+          "instanceName": "other_parties[0].middle_name_label"
+        },
+        "last_name_label": {
+          "_class": "docassemble.base.util.DALazyTemplate",
+          "instanceName": "other_parties[0].last_name_label"
+        },
+        "business_name_label": {
+          "_class": "docassemble.base.util.DALazyTemplate",
+          "instanceName": "other_parties[0].business_name_label"
+        },
+        "person_type": "ALIndividual",
+        "party_type": "20641",
+        "is_new": true,
+        "complete": true
+      }
+    ],
+    "auto_gather": true,
+    "ask_number": false,
+    "minimum_number": null,
+    "object_type": {
+      "_class": "type",
+      "name": "docassemble.AssemblyLine.al_general.ALIndividual"
+    },
+    "object_type_parameters": {},
+    "complete_attribute": "complete",
+    "ask_object_type": false,
+    "there_are_any": true,
+    "there_is_another": false,
+    "gathered": true,
+    "revisit": true
+  },
+  "existing_parties_new_atts": {
+    "_class": "docassemble.base.util.DAList",
+    "instanceName": "existing_parties_new_atts",
+    "elements": [],
+    "auto_gather": true,
+    "ask_number": false,
+    "minimum_number": null,
+    "object_type": {
+      "_class": "type",
+      "name": "docassemble.base.util.DAObject"
+    },
+    "object_type_parameters": {},
+    "complete_attribute": null,
+    "ask_object_type": false,
+    "there_are_any": false,
+    "gathered": true,
+    "revisit": true
+  },
+  "attorney_ids": [],
+  "party_to_attorneys": {
+    "users[0]": {
+      "_class": "docassemble.base.util.DAList",
+      "instanceName": "users[0].attorney_ids",
+      "elements": [],
+      "auto_gather": true,
+      "ask_number": false,
+      "minimum_number": null,
+      "there_are_any": false,
+      "gathered": true,
+      "revisit": true,
+      "object_type": null,
+      "object_type_parameters": {},
+      "complete_attribute": null,
+      "ask_object_type": false
+    }
+  },
+  "all_case_parties": [
+    ["users[0]", "Bryce Willey"],
+    ["other_parties[0]", "Bob Bad"]
+  ],
+  "lead_contact": {
+    "_class": "docassemble.AssemblyLine.al_general.ALIndividual",
+    "instanceName": "users[0]",
+    "name": {
+      "_class": "docassemble.base.util.IndividualName",
+      "instanceName": "users[0].name",
+      "uses_parts": true,
+      "first": "Bryce",
+      "middle": "",
+      "last": "Willey"
+    },
+    "address": {
+      "_class": "docassemble.AssemblyLine.al_general.ALAddress",
+      "instanceName": "users[0].address",
+      "location": {
+        "_class": "docassemble.base.util.LatitudeLongitude",
+        "instanceName": "users[0].address.location",
+        "gathered": false,
+        "known": false
+      },
+      "_geocoded": false,
+      "geolocated": false,
+      "city_only": false
+    },
+    "location": {
+      "_class": "docassemble.base.util.LatitudeLongitude",
+      "instanceName": "users[0].location",
+      "gathered": false,
+      "known": false
+    },
+    "previous_addresses": {
+      "_class": "docassemble.AssemblyLine.al_general.ALAddressList",
+      "instanceName": "users[0].previous_addresses",
+      "elements": [],
+      "auto_gather": true,
+      "ask_number": false,
+      "minimum_number": null,
+      "object_type": {
+        "_class": "type",
+        "name": "docassemble.AssemblyLine.al_general.ALAddress"
+      },
+      "object_type_parameters": {},
+      "complete_attribute": null,
+      "ask_object_type": false
+    },
+    "other_addresses": {
+      "_class": "docassemble.AssemblyLine.al_general.ALAddressList",
+      "instanceName": "users[0].other_addresses",
+      "elements": [],
+      "auto_gather": true,
+      "ask_number": false,
+      "minimum_number": null,
+      "object_type": {
+        "_class": "type",
+        "name": "docassemble.AssemblyLine.al_general.ALAddress"
+      },
+      "object_type_parameters": {},
+      "complete_attribute": null,
+      "ask_object_type": false
+    },
+    "mailing_address": {
+      "_class": "docassemble.AssemblyLine.al_general.ALAddress",
+      "instanceName": "users[0].mailing_address",
+      "location": {
+        "_class": "docassemble.base.util.LatitudeLongitude",
+        "instanceName": "users[0].mailing_address.location",
+        "gathered": false,
+        "known": false
+      },
+      "_geocoded": false,
+      "geolocated": false,
+      "city_only": false
+    },
+    "service_address": {
+      "_class": "docassemble.AssemblyLine.al_general.ALAddress",
+      "instanceName": "users[0].service_address",
+      "location": {
+        "_class": "docassemble.base.util.LatitudeLongitude",
+        "instanceName": "users[0].service_address.location",
+        "gathered": false,
+        "known": false
+      },
+      "_geocoded": false,
+      "geolocated": false,
+      "city_only": false
+    },
+    "previous_names": {
+      "_class": "docassemble.AssemblyLine.al_general.ALNameList",
+      "instanceName": "users[0].previous_names",
+      "elements": [],
+      "auto_gather": true,
+      "ask_number": false,
+      "minimum_number": null,
+      "object_type": {
+        "_class": "type",
+        "name": "docassemble.base.util.IndividualName"
+      },
+      "object_type_parameters": {},
+      "complete_attribute": null,
+      "ask_object_type": false
+    },
+    "aliases": {
+      "_class": "docassemble.AssemblyLine.al_general.ALNameList",
+      "instanceName": "users[0].aliases",
+      "elements": [],
+      "auto_gather": true,
+      "ask_number": false,
+      "minimum_number": null,
+      "object_type": {
+        "_class": "type",
+        "name": "docassemble.base.util.IndividualName"
+      },
+      "object_type_parameters": {},
+      "complete_attribute": null,
+      "ask_object_type": false
+    },
+    "preferred_name": {
+      "_class": "docassemble.base.util.IndividualName",
+      "instanceName": "users[0].preferred_name",
+      "uses_parts": true
+    },
+    "person_type_label": {
+      "_class": "docassemble.base.util.DALazyTemplate",
+      "instanceName": "users[0].person_type_label"
+    },
+    "individual_choice_label": {
+      "_class": "docassemble.base.util.DALazyTemplate",
+      "instanceName": "users[0].individual_choice_label"
+    },
+    "business_choice_label": {
+      "_class": "docassemble.base.util.DALazyTemplate",
+      "instanceName": "users[0].business_choice_label"
+    },
+    "first_name_label": {
+      "_class": "docassemble.base.util.DALazyTemplate",
+      "instanceName": "users[0].first_name_label"
+    },
+    "middle_name_label": {
+      "_class": "docassemble.base.util.DALazyTemplate",
+      "instanceName": "users[0].middle_name_label"
+    },
+    "last_name_label": {
+      "_class": "docassemble.base.util.DALazyTemplate",
+      "instanceName": "users[0].last_name_label"
+    },
+    "business_name_label": {
+      "_class": "docassemble.base.util.DALazyTemplate",
+      "instanceName": "users[0].business_name_label"
+    },
+    "person_type": "ALIndividual",
+    "is_form_filler": false,
+    "email": "bryce.steven.willey+faketylerprose@gmail.com",
+    "party_type": "20646",
+    "is_new": true,
+    "attorney_adding_opts": {
+      "_class": "docassemble.base.util.DADict",
+      "instanceName": "users[0].attorney_adding_opts",
+      "elements": {},
+      "auto_gather": false,
+      "ask_number": false,
+      "minimum_number": null,
+      "object_type": null,
+      "object_type_parameters": {},
+      "complete_attribute": null,
+      "ask_object_type": false,
+      "gathered": true
+    },
+    "attorney_ids": {
+      "_class": "docassemble.base.util.DAList",
+      "instanceName": "users[0].attorney_ids",
+      "elements": [],
+      "auto_gather": true,
+      "ask_number": false,
+      "minimum_number": null,
+      "there_are_any": false,
+      "gathered": true,
+      "revisit": true,
+      "object_type": null,
+      "object_type_parameters": {},
+      "complete_attribute": null,
+      "ask_object_type": false
+    },
+    "complete": true
+  },
+  "contacts_to_attach": {
+    "_class": "docassemble.base.util.DAList",
+    "instanceName": "contacts_to_attach",
+    "elements": [],
+    "auto_gather": true,
+    "ask_number": false,
+    "minimum_number": null,
+    "object_type": {
+      "_class": "type",
+      "name": "docassemble.base.util.DAObject"
+    },
+    "object_type_parameters": {},
+    "complete_attribute": "complete",
+    "ask_object_type": false,
+    "gathered": true
+  },
+  "filing_description_datafield": {
+    "code": "FilingFilingDescription",
+    "name": "Filing window: Filing Description",
+    "isvisible": true,
+    "isrequired": false,
+    "helptext": "",
+    "ghosttext": "",
+    "contextualhelpdata": "",
+    "validationmessage": "",
+    "regularexpression": null,
+    "defaultvalueexpression": "",
+    "isreadonly": "False",
+    "location": "adams"
+  },
+  "service_contacts": {
+    "_class": "docassemble.base.util.DAList",
+    "instanceName": "service_contacts",
+    "elements": [],
+    "auto_gather": true,
+    "ask_number": false,
+    "minimum_number": null,
+    "object_type": {
+      "_class": "type",
+      "name": "docassemble.base.util.DAObject"
+    },
+    "object_type_parameters": {},
+    "complete_attribute": "complete",
+    "ask_object_type": false,
+    "there_are_any": false,
+    "gathered": true,
+    "revisit": true
+  },
+  "al_exhibit_preview_label": {
+    "_class": "docassemble.base.util.DALazyTemplate",
+    "instanceName": "al_exhibit_preview_label"
+  },
+  "al_court_bundle": {
+    "_class": "docassemble.AssemblyLine.al_document.ALDocumentBundle",
+    "instanceName": "al_court_bundle",
+    "elements": [
+      {
+        "_class": "docassemble.AssemblyLine.al_document.ALExhibitDocument",
+        "instanceName": "lead_doc",
+        "elements": {},
+        "auto_gather": true,
+        "ask_number": false,
+        "minimum_number": null,
+        "object_type": null,
+        "object_type_parameters": {},
+        "complete_attribute": null,
+        "ask_object_type": false,
+        "title": "Lead Filing Doc",
+        "filename": "lead_filing_doc",
+        "include_table_of_contents": false,
+        "include_exhibit_cover_pages": false,
+        "overflow_fields": {
+          "_class": "docassemble.AssemblyLine.al_document.ALAddendumFieldDict",
+          "instanceName": "lead_doc.overflow_fields",
+          "elements": {},
+          "auto_gather": false,
+          "ask_number": false,
+          "minimum_number": null,
+          "object_type": {
+            "_class": "type",
+            "name": "docassemble.AssemblyLine.al_document.ALAddendumField"
+          },
+          "object_type_parameters": {},
+          "complete_attribute": null,
+          "ask_object_type": false,
+          "style": "overflow_only"
+        },
+        "default_overflow_message": "...",
+        "has_addendum": false,
+        "cache": {
+          "_class": "docassemble.AssemblyLine.al_document.DALazyAttribute",
+          "instanceName": "lead_doc.cache",
+          "enabled": true
+        },
+        "always_enabled": false,
+        "suffix_to_append": "preview",
+        "exhibits": {
+          "_class": "docassemble.AssemblyLine.al_document.ALExhibitList",
+          "instanceName": "lead_doc.exhibits",
+          "elements": [
+            {
+              "_class": "docassemble.AssemblyLine.al_document.ALExhibit",
+              "instanceName": "lead_doc.exhibits[0]",
+              "_cache": {
+                "_class": "docassemble.AssemblyLine.al_document.DALazyAttribute",
+                "instanceName": "lead_doc.exhibits[0]._cache",
+                "_file": {
+                  "_class": "docassemble.base.util.DAFile",
+                  "instanceName": "lead_doc.exhibits[0]._cache._file",
+                  "has_specific_filename": true,
+                  "ok": true,
+                  "filename": "exhibits.pdf",
+                  "number": 241262,
+                  "extension": "pdf",
+                  "mimetype": "application/pdf",
+                  "file_info": {
+                    "filename": "exhibits.pdf",
+                    "extension": "pdf",
+                    "mimetype": "application/pdf",
+                    "path": "/tmp/files/241262/file",
+                    "fullpath": "/tmp/files/241262/file.pdf",
+                    "private": true,
+                    "persistent": false,
+                    "encrypted": false,
+                    "acroform": true,
+                    "pages": 1
+                  },
+                  "persistent": false,
+                  "private": true,
+                  "initialized": true
+                }
+              },
+              "object_type": {
+                "_class": "type",
+                "name": "docassemble.base.util.DAFileList"
+              },
+              "start_page": 1,
+              "suffix_to_append": "preview",
+              "pages": {
+                "_class": "docassemble.base.util.DAFileList",
+                "instanceName": "lead_doc.exhibits[0].pages",
+                "elements": [
+                  {
+                    "_class": "docassemble.base.util.DAFile",
+                    "instanceName": "lead_doc.exhibits[0].pages[0]",
+                    "filename": "check.pdf",
+                    "has_specific_filename": true,
+                    "mimetype": "application/pdf",
+                    "extension": "pdf",
+                    "number": 241254,
+                    "ok": true,
+                    "initialized": true,
+                    "_taskscreen": "bd3b85a9-a1dd-4e7e-861f-58d726c04a6b",
+                    "_taskpage": "f4e0d8ac-80d8-487c-b5f5-d4587ab1d5fa",
+                    "file_info": {
+                      "filename": "check.pdf",
+                      "extension": "pdf",
+                      "mimetype": "application/pdf",
+                      "path": "/tmp/files/241254/file",
+                      "fullpath": "/tmp/files/241254/file.pdf",
+                      "private": true,
+                      "persistent": false,
+                      "encrypted": false,
+                      "acroform": true,
+                      "pages": 1
+                    },
+                    "persistent": false,
+                    "private": true
+                  }
+                ],
+                "auto_gather": true,
+                "ask_number": false,
+                "minimum_number": null,
+                "there_are_any": true,
+                "object_type": null,
+                "object_type_parameters": {},
+                "complete_attribute": null,
+                "ask_object_type": false,
+                "there_is_another": false,
+                "gathered": true,
+                "revisit": true
+              },
+              "title": "Affidavit",
+              "in_progress_template": {
+                "_class": "docassemble.base.util.DALazyTemplate",
+                "instanceName": "lead_doc.exhibits[0].in_progress_template"
+              },
+              "rearrange_pages_table": {
+                "_class": "docassemble.base.util.DALazyTableTemplate",
+                "instanceName": "lead_doc.exhibits[0].rearrange_pages_table"
+              },
+              "label": "A"
+            }
+          ],
+          "auto_gather": true,
+          "ask_number": false,
+          "minimum_number": null,
+          "object_type": {
+            "_class": "type",
+            "name": "docassemble.AssemblyLine.al_document.ALExhibit"
+          },
+          "object_type_parameters": {},
+          "complete_attribute": "complete",
+          "ask_object_type": false,
+          "auto_label": true,
+          "auto_labeler": null,
+          "auto_ocr": false,
+          "include_table_of_contents": false,
+          "include_exhibit_cover_pages": false,
+          "bates_prefix": "",
+          "suffix_to_append": "preview",
+          "there_are_any": true,
+          "in_progress_exhibits": {
+            "_class": "docassemble.base.util.DALazyTemplate",
+            "instanceName": "lead_doc.exhibits.in_progress_exhibits"
+          },
+          "rearrange_exhibits_table": {
+            "_class": "docassemble.base.util.DALazyTableTemplate",
+            "instanceName": "lead_doc.exhibits.rearrange_exhibits_table"
+          },
+          "there_is_another": false,
+          "gathered": true,
+          "revisit": true
+        },
+        "add_page_numbers": false,
+        "optional_services_defaults": [],
+        "optional_services_filters": [],
+        "filing_type": "143127",
+        "filing_description": "",
+        "reference_number": "",
+        "has_courtesy_copies": false,
+        "document_type_default": null,
+        "document_type_filters": [],
+        "filtered_document_type_options": [
+          ["5766", "Non-Confidential"],
+          ["5767", "Confidential"]
+        ],
+        "user_chosen_document_type": "5766",
+        "document_type": "5766",
+        "motion_type_options": [],
+        "motion_type_map": {},
+        "motion_type": null,
+        "filing_component_default": null,
+        "filing_component_filters": [],
+        "filtered_filing_component_options": [
+          ["331", "Attachments"],
+          ["332", "Lead Document"]
+        ],
+        "user_chosen_filing_component": "332",
+        "filing_component": "332",
+        "filing_parties": ["users[0]"],
+        "filing_action": "efile",
+        "optional_services": {
+          "_class": "docassemble.base.util.DAList",
+          "instanceName": "lead_doc.optional_services",
+          "elements": [],
+          "auto_gather": true,
+          "ask_number": false,
+          "minimum_number": null,
+          "object_type": {
+            "_class": "type",
+            "name": "docassemble.base.util.DAObject"
+          },
+          "object_type_parameters": {},
+          "complete_attribute": "complete",
+          "ask_object_type": false,
+          "there_are_any": false,
+          "gathered": true,
+          "revisit": true
+        },
+        "added_necessary_opt_services": true,
+        "completed": true,
+        "proxy_enabled": true,
+        "data_url": "https://africau.edu/images/default/sample.pdf",
+        "page_count": 1
+      }
+    ],
+    "ask_number": false,
+    "minimum_number": null,
+    "object_type": {
+      "_class": "type",
+      "name": "docassemble.AssemblyLine.al_document.ALExhibitDocument"
+    },
+    "object_type_parameters": {},
+    "complete_attribute": "completed",
+    "ask_object_type": false,
+    "filename": "full_bundle.pdf",
+    "title": "All forms to submit to the court",
+    "gathered": true,
+    "auto_gather": true,
+    "there_are_any": true,
+    "cache": {
+      "_class": "docassemble.AssemblyLine.al_document.DALazyAttribute",
+      "instanceName": "al_court_bundle.cache",
+      "final": {
+        "_class": "docassemble.base.util.DAFile",
+        "instanceName": "al_court_bundle.cache.final",
+        "has_specific_filename": true,
+        "ok": true,
+        "filename": "lead_filing_doc.pdf",
+        "number": 241263,
+        "extension": "pdf",
+        "mimetype": "application/pdf",
+        "file_info": {
+          "filename": "lead_filing_doc.pdf",
+          "extension": "pdf",
+          "mimetype": "application/pdf",
+          "path": "/tmp/files/241263/file",
+          "fullpath": "/tmp/files/241263/file.pdf",
+          "private": true,
+          "persistent": false,
+          "encrypted": false,
+          "acroform": true,
+          "pages": 1
+        },
+        "persistent": false,
+        "private": true,
+        "initialized": true,
+        "title": "All forms to submit to the court"
+      }
+    },
+    "always_enabled": false,
+    "suffix_to_append": "preview",
+    "there_is_another": false,
+    "revisit": true
+  },
+  "append_lead_doc": true,
+  "service_type_options": [["-580", "EServe"]],
+  "service_type_map": {
+    "-580": {
+      "code": "-580",
+      "name": "EServe",
+      "servicemethod": "ESERVICE",
+      "fee": "",
+      "disclaimertext": ""
+    }
+  },
+  "cross_ref_types": [],
+  "cross_ref_type_map": {},
+  "cross_references": {
+    "_class": "docassemble.base.util.DADict",
+    "instanceName": "cross_references",
+    "elements": {},
+    "auto_gather": true,
+    "ask_number": false,
+    "minimum_number": null,
+    "object_type": null,
+    "object_type_parameters": {},
+    "complete_attribute": null,
+    "ask_object_type": false,
+    "there_are_any": 0,
+    "gathered": true,
+    "revisit": true
+  },
+  "explain_user_paying": true,
+  "allowable_card_types": [
+    "MASTERCARD",
+    "VISA",
+    "AMEX",
+    "DISCOVER",
+    "CHECKING"
+  ],
+  "res": [
+    {
+      "accountName": "global_credit_card",
+      "paymentAccountTypeCodeId": null,
+      "accountToken": "197944493",
+      "cardType": {
+        "name": "{urn:tyler:efm:services:schema:Common}CardType",
+        "declaredType": "java.lang.String",
+        "scope": "tyler.efm.services.schema.common.PaymentAccountType",
+        "value": "MASTERCARD",
+        "nil": false,
+        "globalScope": false,
+        "typeSubstituted": false
+      },
+      "cardLast4": "5454",
+      "cardMonth": {
+        "name": "{urn:tyler:efm:services:schema:Common}CardMonth",
+        "declaredType": "java.lang.Integer",
+        "scope": "tyler.efm.services.schema.common.PaymentAccountType",
+        "value": 12,
+        "nil": false,
+        "globalScope": false,
+        "typeSubstituted": false
+      },
+      "cardYear": {
+        "name": "{urn:tyler:efm:services:schema:Common}CardYear",
+        "declaredType": "java.lang.Integer",
+        "scope": "tyler.efm.services.schema.common.PaymentAccountType",
+        "value": 2023,
+        "nil": false,
+        "globalScope": false,
+        "typeSubstituted": false
+      },
+      "cardHolderName": {
+        "name": "{urn:tyler:efm:services:schema:Common}CardHolderName",
+        "declaredType": "java.lang.String",
+        "scope": "tyler.efm.services.schema.common.PaymentAccountType",
+        "value": "BB WW",
+        "nil": false,
+        "globalScope": false,
+        "typeSubstituted": false
+      },
+      "active": {
+        "name": "{urn:tyler:efm:services:schema:Common}Active",
+        "declaredType": "java.lang.Boolean",
+        "scope": "tyler.efm.services.schema.common.PaymentAccountType",
+        "value": true,
+        "nil": false,
+        "globalScope": false,
+        "typeSubstituted": false
+      },
+      "isAvailableAtAllLocations": null,
+      "courtIdentifier": [],
+      "paymentAccountLocationDetails": null,
+      "availableLocationNodes": [],
+      "paymentAccountID": "ab5ec14b-a063-45fb-b38d-6b364b169db5",
+      "firmID": null,
+      "paymentAccountTypeCode": "CC"
+    },
+    {
+      "accountName": "Global Account",
+      "paymentAccountTypeCodeId": null,
+      "accountToken": null,
+      "cardType": null,
+      "cardLast4": null,
+      "cardMonth": null,
+      "cardYear": null,
+      "cardHolderName": null,
+      "active": {
+        "name": "{urn:tyler:efm:services:schema:Common}Active",
+        "declaredType": "java.lang.Boolean",
+        "scope": "tyler.efm.services.schema.common.PaymentAccountType",
+        "value": true,
+        "nil": false,
+        "globalScope": false,
+        "typeSubstituted": false
+      },
+      "isAvailableAtAllLocations": null,
+      "courtIdentifier": [],
+      "paymentAccountLocationDetails": null,
+      "availableLocationNodes": [],
+      "paymentAccountID": "75950d4b-f3c3-4748-8bfb-0e22790d19d7",
+      "firmID": null,
+      "paymentAccountTypeCode": "WV"
+    }
+  ],
+  "tyler_payment_account_options": [
+    [
+      "e9cd74e2-ee91-4706-a25c-cac6865013c8",
+      "Very Normal MasterCard (MASTERCARD, 5454)"
+    ],
+    ["9014c150-b96e-45c7-8077-2b91a6ded5d4", "Echeck (BankAccount)"],
+    [
+      "ab5ec14b-a063-45fb-b38d-6b364b169db5",
+      "global_credit_card (MASTERCARD, 5454)"
+    ],
+    ["75950d4b-f3c3-4748-8bfb-0e22790d19d7", "Global Account (Waiver account)"]
+  ],
+  "admin_interview": "docassemble.EFSPIntegration:admin_interview.yml",
+  "tyler_payment_id": "75950d4b-f3c3-4748-8bfb-0e22790d19d7",
+  "disclaimers": [],
+  "show_any_disclaimers": true
+}


### PR DESCRIPTION
Improve the `integration_test.py` test:

* can be run from other python files, particularly [from python files in EfileProxyServer](https://github.com/SuffolkLITLab/EfileProxyServer/pull/139/files#diff-1633196318a48ed42103653fbdf6e7c275dcd81969444fc01a47ae28beff077d)
* better tests of HATEOS (checking as many endpoints as feasibly possible
* adds back filing review tests