### PR TITLE
Added ready_to_efile_user_hook

### DIFF
--- a/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
+++ b/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
@@ -222,6 +222,7 @@ need:
 id: ready_to_efile
 code: |
   # Ask for the clerk comments, they'll go in the lead filing doc comments
+  ready_to_efile_user_hook
   check_resp
   remaining_to_check = check_resp.data
   log('check_resp: ' + str(check_resp))
@@ -249,12 +250,16 @@ code: |
   if not ready_to_efile:
     show_no_efile
 ---
+code: |
+  ready_to_efile_user_hook = True
+---
 id: actually efile
 depends on:
   - can_check_efile
   - user_wants_efile
 if: can_check_efile and user_wants_efile and ready_to_efile
 code: |
+  tyler_payment_id
   efile_user_reviewed
   if not efile_author_mode:
     prevent_going_back()
@@ -819,10 +824,10 @@ code: |
     tyler_payment_account_options = filter_payment_accounts(res, allowable_card_types)
   else:
     tyler_payment_account_options = []
-
-  res = proxy_conn.get_global_payment_account_list().data
-  if res:
-    tyler_payment_account_options.extend(filter_payment_accounts(res, allowable_card_types))
+  # For now, don't show global options for payment accounts.
+  #res = proxy_conn.get_global_payment_account_list().data
+  #if res:
+  #  tyler_payment_account_options.extend(filter_payment_accounts(res, allowable_card_types))
 ---
 ################################
 ## Fees

--- a/docassemble/EFSPIntegration/data/questions/toga_payments_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/toga_payments_interview.yml
@@ -4,11 +4,11 @@ include:
 ---
 variable name: jurisdiction_names
 data:
-  - illinois: Illinois
-  - massachusetts: Massachusetts
-  - texas: Texas
-  - california: California
-  - indiana: Indiana
+  illinois: Illinois
+  massachusetts: Massachusetts
+  texas: Texas
+  california: California
+  indiana: Indiana
 ---
 need:
   - tyler_login

--- a/docassemble/EFSPIntegration/test/integration_test.py
+++ b/docassemble/EFSPIntegration/test/integration_test.py
@@ -61,7 +61,7 @@ class TestClass:
         self.user_password = user_password
 
     def basic_assert(self, resp: ApiResponse):
-        if self.verbose:
+        if self.verbose or not resp.is_ok():
             print(resp)
         assert resp.is_ok()
         return resp
@@ -534,6 +534,7 @@ def main(*, base_url, api_key, user_email=None, user_password=None):
     tc.test_logs()
     # TODO(brycew): needs a more up to date JSON from any filing interiview
     tc.test_filings()
+    print("Done!")
     # TODO(brycew): Tyler issue, have to wait on them
     # tc.test_global_payment_accounts()
     proxy_conn.proxy_client.close()


### PR DESCRIPTION
And some quick payments improvements as well:

* `toga_payments_interview.yml` used the wrong data block
* need to ask directly for the `tyler_payment_id` var before filing
* We shouldn't show all users the global payment methods, as they'll either be waivers and should be restricted, or we, the EFSP, shouldn't be using them