### PR TITLE
Monitoring

### DIFF
--- a/docassemble/EFSPIntegration/conversions.py
+++ b/docassemble/EFSPIntegration/conversions.py
@@ -45,10 +45,10 @@ __all__ = [
 
 TypeType = type(type(None))
 
-def log_error_and_notify(context: str, resp: ApiResponse):
+def log_error_and_notify(context: str, resp: Optional[ApiResponse] = None):
     """Similar to docassemble.webapp.server.error_notification, which will send an email to
     the `error_notification_email` in the config."""
-    message = "context: {context};; resp: {resp}"
+    message = f"context: {context};; resp: {resp}"
     log(f"EFSPIntegration ERROR: {message}")
     error_notification(resp, message=message)
 

--- a/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
+++ b/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
@@ -231,7 +231,7 @@ code: |
     if efile_author_mode:
       show_remaining
     else:
-      log(f'Something went wrong: {check_resp.error_msg}')
+      log_error_and_notify('Check response failed', check_resp)
   elif not remaining_to_check.get("required_vars") and not remaining_to_check.get("wrong_vars"):
     ready_to_efile = True
   else:
@@ -874,7 +874,7 @@ code: |
 code: |
   fees_resp = proxy_conn.calculate_filing_fees(court_id, al_court_bundle)
   if not fees_resp.is_ok():
-    log(f'fees not ok! {fees_resp}')
+    log_error_and_notify('Fees not ok', fees_resp)
 ---
 depends on:
   - fees_resp

--- a/docassemble/EFSPIntegration/interview_logic.py
+++ b/docassemble/EFSPIntegration/interview_logic.py
@@ -307,7 +307,7 @@ def get_full_court_info(proxy_conn, court_id: str) -> Dict:
     if full_court_resp.is_ok():
         return full_court_resp.data
     else:
-        log(f"Couldn't get full court info for {court_id}: {full_court_resp}")
+        log_error_and_notify(f"Couldn't get full court info for {court_id}", full_court_resp)
         return {}
 
 

--- a/docassemble/EFSPIntegration/interview_logic.py
+++ b/docassemble/EFSPIntegration/interview_logic.py
@@ -17,7 +17,7 @@ from typing import (
 from datetime import datetime
 
 from docassemble.base.util import CustomDataType, DAObject, DAList, log, word
-from .conversions import parse_case_info, fetch_case_info, chain_xml
+from .conversions import parse_case_info, fetch_case_info, chain_xml, log_error_and_notify
 from docassemble.AssemblyLine.al_general import ALPeopleList, ALIndividual
 
 
@@ -236,7 +236,7 @@ def search_case_by_name(
                 found_cases.pop()
             log(f"done with {idx} in search_case_by_name, {new_case.as_serializable()}")
     else:
-        log(f"get_cases_response: {get_cases_response}")
+        log_error_and_notify("get_cases_response failed when searching for case", get_cases_response)
         found_cases.resp_ok = False
     found_cases.gathered = True
     return cms_connection_issue, found_cases
@@ -455,8 +455,8 @@ def get_available_efile_courts(proxy_conn) -> list:
         if court_list.is_ok():
             return sorted(court_list.data or [])
         else:
-            log(f"Couldn't get courts from proxy server? {court_list}")
+            log_error_and_notify("Couldn't get courts from proxy server?", court_list)
             return []
     else:
-        log(f"Couldn't login to the proxy server!: {resp}")
+        log_error_and_notify("Couldn't login to the proxy server", resp)
         return []


### PR DESCRIPTION
logs the error and also send an error via the same mechanism
that `error notification email` in the config works. So, we can
still recover and handle errors correctly, while notifying the
server admin that something has gone wrong.