### PR TITLE
Updates for MA Production

### DIFF
--- a/docassemble/EFSPIntegration/data/questions/admin_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/admin_interview.yml
@@ -1295,14 +1295,6 @@ question: |
 subquestion: |
   ${ error_message }
 ---
-variable name: jurisdiction_names
-data:
-  illinois: Illinois
-  massachusetts: Massachusetts
-  texas: Texas
-  california: California
-  indiana: Indiana
----
 code: |
   case_category_options, case_category_map = choices_and_map(proxy_conn.get_case_categories(court_id, fileable_only=False, timing=None).data)
 ---

--- a/docassemble/EFSPIntegration/data/questions/any_filing_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/any_filing_interview.yml
@@ -14,14 +14,6 @@ include:
 code: |
   user_wants_efile = True # This interview is always for e-filing
 ---
-variable name: jurisdiction_names
-data:
-  illinois: Illinois
-  massachusetts: Massachusetts
-  texas: Texas
-  california: California
-  indiana: Indiana
----
 objects:
   - case_search: EFCaseSearch.using(court_id=court_id)
   - lower_court_case: DAObject

--- a/docassemble/EFSPIntegration/data/questions/any_filing_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/any_filing_interview.yml
@@ -474,7 +474,7 @@ code: |
     party_to_attorneys[y.existing_party] = y.attorney_ids
 ---
 id: location
-question: | 
+question: |
   What court will you file this case in?
 fields:
   - Court Location: trial_court

--- a/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
+++ b/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
@@ -985,12 +985,14 @@ code: |
     users[i].is_form_filler = False
 ---
 code: |
+  firm_details = proxy_conn.get_firm()
+---
+code: |
   # Seeing if a user is a firm can only be done by checking getFirm()["isIndividual"]
   # getFirm is valid for all users, and is where the address is for individuals
   if not can_check_efile:
     users[0].is_form_filler = False
   else:
-    firm_details = proxy_conn.get_firm()
     if firm_details.is_ok() and firm_details.data.get("isIndividual", False):
       users[0].is_form_filler = False
 ---

--- a/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
+++ b/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
@@ -985,11 +985,14 @@ code: |
     users[i].is_form_filler = False
 ---
 code: |
-  # Can only get the attorney list for firm users, which can't be form fillers
+  # Seeing if a user is a firm can only be done by checking getFirm()["isIndividual"]
+  # getFirm is valid for all users, and is where the address is for individuals
   if not can_check_efile:
     users[0].is_form_filler = False
-  elif proxy_conn.get_attorney_list().is_ok():
-    users[0].is_form_filler = False
+  else:
+    firm_details = proxy_conn.get_firm()
+    if firm_details.is_ok() and firm_details.data.get("isIndividual", False):
+      users[0].is_form_filler = False
 ---
 need: proxy_conn
 if: users[0].is_form_filler

--- a/docassemble/EFSPIntegration/data/questions/login_qs.yml
+++ b/docassemble/EFSPIntegration/data/questions/login_qs.yml
@@ -310,12 +310,3 @@ only sets: full_court_info
 code: |
   full_court_info = get_full_court_info(proxy_conn, court_id)
 ---
-variable name: jurisdiction_names
-data:
-  illinois: Illinois
-  massachusetts: Massachusetts
-  texas: Texas
-  california: California
-  indiana: Indiana
-  louisiana: Louisiana
----

--- a/docassemble/EFSPIntegration/data/questions/login_qs.yml
+++ b/docassemble/EFSPIntegration/data/questions/login_qs.yml
@@ -310,14 +310,6 @@ only sets: full_court_info
 code: |
   full_court_info = get_full_court_info(proxy_conn, court_id)
 ---
-id: which-jurisdiction
-question: |
-  Which jurisdiction are you filing in?
-fields:
-  - no label: jurisdiction_id
-    code: |
-      [{k: v} for k, v in jurisdiction_names.items() if k in jurisdiction_choices]
----
 variable name: jurisdiction_names
 data:
   illinois: Illinois
@@ -327,14 +319,3 @@ data:
   indiana: Indiana
   louisiana: Louisiana
 ---
-imports:
-  - requests
----
-code: |
-  if 'jurisdiction_id' in url_args:
-    jurisdiction_id = url_args['jurisdiction_id']
-  try:
-    jurisdiction_choices = set(requests.get(get_config("efile proxy", {}).get("url", "") + "/jurisdictions").json().keys())
-  except (requests.exceptions.MissingSchema, requests.exceptions.ConnectionError, requests.exceptions.JSONDecodeError) as ex:
-    log(f"Couldn't connect with the efile proxy server! {ex}")
-    jurisdiction_id = ""

--- a/docassemble/EFSPIntegration/data/questions/toga_payments_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/toga_payments_interview.yml
@@ -2,15 +2,6 @@ include:
   - login_qs.yml
   - toga_payments.yml
 ---
-# overriden from toga_payments to remove Louisana, not a Tyler jurisdiction
-variable name: jurisdiction_names
-data:
-  illinois: Illinois
-  massachusetts: Massachusetts
-  texas: Texas
-  california: California
-  indiana: Indiana
----
 # Overriden from toga_payments to remove the "you can go back"
 need:
   - tyler_login

--- a/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
+++ b/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
@@ -64,6 +64,16 @@ code: |
     log_error_and_notify(f"Couldn't connect with the efile proxy server! {ex}")
     jurisdiction_id = ""
 ---
+# Note the lack of Louisana, not a Tyler jurisdiction. Can still be set manually
+variable name: jurisdiction_names
+data:
+  illinois: Illinois
+  massachusetts: Massachusetts
+  texas: Texas
+  california: California
+  indiana: Indiana
+
+---
 code: |
   can_connect_to_proxy = proxy_conn.get_server_name().is_ok()
 ---

--- a/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
+++ b/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
@@ -24,7 +24,7 @@ objects:
 ---
 variable name: account_action_list
 data: !!omap
-  - register: "Register"
+  - register: "Create an e-filing account"
   - reset_user_password: "Reset your password"
   - self_resend_activation: "Resend activation email"
 ---

--- a/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
+++ b/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
@@ -15,6 +15,9 @@ modules:
   - .efm_client
   - .conversions
 ---
+imports:
+  - requests
+---
 include:
   - docassemble.ALToolbox:phone-number-validation.yml
   - docassemble.AssemblyLine:assembly_line.yml
@@ -43,6 +46,23 @@ code: |
 ---
 code: |
   proxy_conn = ProxyConnection(credentials_code_block='', default_jurisdiction=jurisdiction_id)
+---
+id: which-jurisdiction
+question: |
+  Which jurisdiction are you filing in?
+fields:
+  - no label: jurisdiction_id
+    code: |
+      [{k: v} for k, v in jurisdiction_names.items() if k in jurisdiction_choices]
+---
+code: |
+  if 'jurisdiction_id' in url_args:
+    jurisdiction_id = url_args['jurisdiction_id']
+  try:
+    jurisdiction_choices = set(requests.get(get_config("efile proxy", {}).get("url", "") + "/jurisdictions").json().keys())
+  except (requests.exceptions.MissingSchema, requests.exceptions.ConnectionError, requests.exceptions.JSONDecodeError) as ex:
+    log_error_and_notify(f"Couldn't connect with the efile proxy server! {ex}")
+    jurisdiction_id = ""
 ---
 code: |
   can_connect_to_proxy = proxy_conn.get_server_name().is_ok()

--- a/docassemble/EFSPIntegration/data/questions/unauthenticated_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/unauthenticated_interview.yml
@@ -7,10 +7,6 @@ data: !!omap
   - INDIVIDUAL: Self-represented user
   - "FIRM_ADMINISTRATOR": Administrator of a new firm
 ---
-code: |
-  if 'jurisdiction_id' in url_args:
-    jurisdiction_id = url_args['jurisdiction_id']
----
 mandatory: True
 id: main-unauth-page
 event: main_unauth_page

--- a/docassemble/EFSPIntegration/data/questions/unauthenticated_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/unauthenticated_interview.yml
@@ -10,8 +10,6 @@ data: !!omap
 code: |
   if 'jurisdiction_id' in url_args:
     jurisdiction_id = url_args['jurisdiction_id']
-  else:
-    jurisdiction_id = 'illinois'
 ---
 mandatory: True
 id: main-unauth-page

--- a/docassemble/EFSPIntegration/interview_logic.py
+++ b/docassemble/EFSPIntegration/interview_logic.py
@@ -104,6 +104,7 @@ def address_fields_with_defaults(
     proxy_conn, person: ALIndividual, is_admin: bool, **kwargs
 ):
     address_fields = person.address_fields(**kwargs)
+    log(address_fields)
     # Efiling requires zip most of the time, enough for us to require it
     for field in address_fields:
         if field.get("field", "").endswith(".zip"):
@@ -112,6 +113,7 @@ def address_fields_with_defaults(
         # Don't autofill if the person is an admin
         return address_fields
     firm_info = proxy_conn.get_firm()
+    log(firm_info)
     if firm_info.is_ok():
         if "address" in firm_info.data:
             for field in address_fields:

--- a/docassemble/EFSPIntegration/interview_logic.py
+++ b/docassemble/EFSPIntegration/interview_logic.py
@@ -104,7 +104,6 @@ def address_fields_with_defaults(
     proxy_conn, person: ALIndividual, is_admin: bool, **kwargs
 ):
     address_fields = person.address_fields(**kwargs)
-    log(address_fields)
     # Efiling requires zip most of the time, enough for us to require it
     for field in address_fields:
         if field.get("field", "").endswith(".zip"):
@@ -113,7 +112,6 @@ def address_fields_with_defaults(
         # Don't autofill if the person is an admin
         return address_fields
     firm_info = proxy_conn.get_firm()
-    log(firm_info)
     if firm_info.is_ok():
         if "address" in firm_info.data:
             for field in address_fields:
@@ -127,7 +125,6 @@ def address_fields_with_defaults(
                     field["default"] = firm_info.data["address"].get("state")
                 if field.get("field", "").endswith(".zip"):
                     field["default"] = firm_info.data["address"].get("zipCode")
-    log(f"final address fields: {address_fields}")
     return address_fields
 
 

--- a/docassemble/EFSPIntegration/interview_logic.py
+++ b/docassemble/EFSPIntegration/interview_logic.py
@@ -127,6 +127,7 @@ def address_fields_with_defaults(
                     field["default"] = firm_info.data["address"].get("state")
                 if field.get("field", "").endswith(".zip"):
                     field["default"] = firm_info.data["address"].get("zipCode")
+    log(f"final address fields: {address_fields}")
     return address_fields
 
 


### PR DESCRIPTION
Includes several smaller changes that I made when testing MA in production:

* Use the intended way to see if people are individuals. Strangely, to see if a user is an individual vs a part of a firm, you have to call "getFirm()" which all users have (it's where the address is for individuals) and check the `isIndividual` attribute. This should reduce the number of false positives Tyler Error logs that we trigger on the proxy server, specifically "Operation not available for individual filers". This was something we had used in a few places in other functions, but we didn't discover that until fairly far through initial development, so this replaces the remaining places that we need to know if an individual is filing with the new method.
* Don't default the unauthenticated interview to the Illinois jurisdiction. With `ILAOEfile` and `MassAccess` overriding the unauthenticated interview, and specifically restricting it to each of their jurisdiction, and only allowing people to make individual filer accounts, we do need a way to test and create Firm admin accounts for any jurisdiction (specifically needed to make a firm account for the LIT Lab to make a Global Fee waiver payment account). As a result of this, we needed to move a few other pieces to the `unauthenticated_actions.yml` file, mostly just:
    * `jurisdiction_names`, the list of jurisdiction names that the given interview supports
    * `jurisdiction_choices`, the list of jurisdictions that the e-file proxy supports, retrieved with a `requests.get` call to the server's `/jurisdictions` endpoint.