### PR TITLE
Filer type in Docassemble

### DIFF
--- a/docassemble/EFSPIntegration/data/questions/any_filing_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/any_filing_interview.yml
@@ -391,6 +391,14 @@ choices:
   - I am starting a new case: initial_document
   - I am adding a document to an existing case: existing_case
 ---
+if: not full_court_info.get("initial")
+code: |
+  filing_interview_initial_or_existing = "existing_case"
+---
+if: not full_court_info.get("subsequent")
+code: |
+  filing_interview_initial_or_existing = "initial_document"
+---
 code: |
   is_initial_filing = filing_interview_initial_or_existing == 'initial_document'
 ---

--- a/docassemble/EFSPIntegration/data/questions/any_filing_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/any_filing_interview.yml
@@ -73,6 +73,7 @@ code: |
   existing_parties_new_atts.gather(complete_attribute='attorney_ids')
   attorney_ids
   party_to_attorneys
+  filer_type
   if not needs_all_info:
     target_case = case_search
   all_case_parties

--- a/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
+++ b/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
@@ -767,6 +767,10 @@ if: len(filer_type_options) == 0
 code: |
   filer_type = ""
 ---
+if: len(filer_type_options) == 1
+code: |
+  filer_type = filer_type_options[0][0]
+---
 code: |
   all_case_parties_tmp = []
   for u in users + other_parties:

--- a/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
+++ b/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
@@ -751,6 +751,22 @@ fields:
     code: |
       sorted(case_type_options,key=lambda cat: cat[1])
 ---
+id: filer type
+question: |
+  Filer Type
+fields:
+  - Filer Type: filer_type
+    datatype: dropdown
+    code: |
+      sorted(filer_type_options, key=lambda filer: filer[1])
+---
+code: |
+  filer_type_options, filer_type_map = choices_and_map(proxy_conn.get_filer_types(court_id).data)
+---
+if: len(filer_type_options) == 0
+code: |
+  filer_type = ""
+---
 code: |
   all_case_parties_tmp = []
   for u in users + other_parties:

--- a/docassemble/EFSPIntegration/py_efsp_client.py
+++ b/docassemble/EFSPIntegration/py_efsp_client.py
@@ -877,6 +877,10 @@ class EfspConnection:
         )
         return self._call_proxy(send)
 
+    def get_filer_types(self, court_id: str) -> ApiResponse:
+        send = lambda: self.proxy_client.get(self.full_url(f"codes/courts/{court_id}/filer_types"))
+        return self._call_proxy(send)
+
     def get_case_types(
         self, court_id: str, case_category: str, timing: str = None
     ) -> ApiResponse:


### PR DESCRIPTION
Adds support of the Filer type, an uncommon court code used (and required) in some Texas jurisdictions.

* adds a method to get the types from the EfileProxy endpoint
* adds a default question, with things to fill it in if there aren't any or only one `filer_types`
* misc addition to the `any_filing_interview`, to not let you try to make an initial filing when the court won't let you
 
Corresponding PR is EfileProxy: https://github.com/SuffolkLITLab/EfileProxyServer/pull/158

