### PR TITLE
Actually notify errors

### DIFF
--- a/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
+++ b/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
@@ -892,15 +892,6 @@ subquestion: |
   There are no fees associated with this filing.
 continue button field: review_fees_screen
 ---
-id: bad fees
-event: bad_fees
-question: |
-  Something went wrong
-subquestion: |
-  Sorry, something went wrong when trying to figure out if you have to pay fees.
- 
-  More details: ${ debug_display(fees_resp) }
----
 depends on:
   - fees_resp
 code: |
@@ -940,7 +931,7 @@ code: |
   if fees_resp.is_ok():
     review_fees_screen
   else:
-    bad_fees
+    raise Exception(f"Was not able to calculate fees: {fees_resp}")
   review_fees = True
 ---
 #############################

--- a/docassemble/EFSPIntegration/data/questions/login_qs.yml
+++ b/docassemble/EFSPIntegration/data/questions/login_qs.yml
@@ -45,7 +45,10 @@ code: |
     tyler_login_resp = proxy_conn.authenticate_user(tyler_email=my_username, tyler_password=my_password)
     del my_password
     if not tyler_login_resp.is_ok():
-      log(f'Failed to login: {tyler_login_resp}')
+      if int(tyler_login_resp.response_code) != 403:
+        log_error_and_notify('Failed to login', tyler_login_resp)
+      else:
+        log(f'Failed to login: {tyler_login_resp}')
       login_failed_screen
     else:
       log(word("You are now connected to your e-filing account"), "primary")


### PR DESCRIPTION
`error_notification`, the function called from `log_error_and_notify` that sends an email to the docassemble error email in the config, had been broken, silently, since nothing was logging in the `try: except` blocks. Started logging those issues, and fixed them locally.

Also:

* Removed `the_vars`, which was causing the error (couldn't open the tmp json
  file), so we won't get the full interview context with the emails (should
  be okay)
* Send that email error notification if the user fails to login for any reason
  (besides a 403) 
* Replaced the `bad_fees` screen with our standard bug screen. That's one of the few screens that's a hard block on E-filing interviews, and is more confusing to users than otherwise. It's better to just say "something went wrong" and give them their options (should make sure they're able to download their forms at that point, but that's a separate thing).