### PR TITLE
Fix required zip attribute

### DIFF
--- a/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
+++ b/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
@@ -161,7 +161,7 @@ fields:
   - note: |
       ---
   - code: |
-      person_to_reg.address_fields(required={"zip": True})
+      person_to_reg.address_fields(required={"person_to_reg.address.zip": True})
 ---
 code: |
   password_rules_resp = proxy_conn.get_password_rules()


### PR DESCRIPTION
Has to actually use the full object / attribute name, not just the attribute name. No other good way around it.