### PR TITLE
Pin tests for only DA 1.6.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 rcfile
 **/.mypy_cache/**
 build/
+.DS_Store
 
 # Kiln stuff
 alkiln_tests_*
@@ -16,3 +17,7 @@ alkiln-*
 cucumber-report.txt
 debug_log.txt
 runtime_config.json
+
+# Python Test stuff
+.coverage
+coverage_html

--- a/docassemble/EFSPIntegration/requirements.txt
+++ b/docassemble/EFSPIntegration/requirements.txt
@@ -1,5 +1,5 @@
-docassemble.base>=1.3
-docassemble.webapp
+docassemble.base==1.6.5
+docassemble.webapp==1.6.5
 docassemble.AssemblyLine>2.10.1
 requests>2.25.1
 types-requests


### PR DESCRIPTION
1.8.X are too big for GHA, and 1.7.X use a version of multidict that was yanked.

Will merge instead of #276 for now, though `uv` builds will still eventually get merged.