### PR TITLE
Fix attribute issue

### DIFF
--- a/docassemble/EFSPIntegration/efm_client.py
+++ b/docassemble/EFSPIntegration/efm_client.py
@@ -20,7 +20,12 @@ from docassemble.base.util import (
 )
 from docassemble.AssemblyLine.al_document import ALDocumentBundle
 from docassemble.AssemblyLine.al_general import ALIndividual
-from .py_efsp_client import ApiResponse, EfspConnection, _user_visible_resp
+from .py_efsp_client import (
+    ApiResponse,
+    LoggerWithContext,
+    EfspConnection,
+    _user_visible_resp,
+)
 
 __all__ = ["ApiResponse", "ProxyConnection", "state_name_to_code"]
 
@@ -186,6 +191,16 @@ class ProxyConnection(EfspConnection):
         except requests.exceptions.InvalidURL as ex:
             return _user_visible_resp(f"Url {self.base_url} is not valid: {ex}")
         return _user_visible_resp(resp)
+
+    def get_logger(self):
+        if not hasattr(self, "logger"):
+            # Copying what we do in `EfspConnection.get_logger` because it needs to
+            # wrap the logger we're trying to make here.
+            self.logger = LoggerWithContext(
+                DALogger(logging.getLogger("docassemble")),
+                {"session_id": self.get_session_id()},
+            )
+        return self.logger
 
     def authenticate_user(
         self,


### PR DESCRIPTION
(Tested locally on interviews started with 1.6.0, and upgraded to this instead of 1.7.0).

Forgot that in docassemle, you can't assume your objects will be correctly initialized, and should do it on the fly.

Fixed this issue for `session_id` and `logger`, the two attributes that were added in #274. Have to handle the session ID in just the parent class (`EfspConnection`), but need to handle the logger in both the parent and child class (`ProxyConnection`).

(Have to have the methods in the parent class at all because the child class because the parent class would have the same issues. This makes separating out a full python client more complicated than I realized unfortunately

Reintegrating myself into the world of DA, one fix at a time).