### PR TITLE
Warn when no codes match the given filters

### DIFF
--- a/docassemble/EFSPIntegration/interview_logic.py
+++ b/docassemble/EFSPIntegration/interview_logic.py
@@ -458,8 +458,14 @@ def filter_codes(
     if len(codes) == 1:
         return codes, codes[0][0]
     elif len(codes) == 0:
+        log_error_and_notify(
+            f"Warning! No existing codes matched filters ({filters})! Falling back to default, but this is unchecked and dangerous. It will be removed in the future. (all of the options: {options})"
+        )
         return list(options), default
     else:
+        log(
+            f"Warning! More than one code matched filters ({filters})! This can result in a worse UX for users. (the found options ({codes}))"
+        )
         return codes, None
 
 


### PR DESCRIPTION
Using a default / hard coded value that isn't checked at runtime to send to Tyler, when triggered, will likely always result in an error from Tyler. This behavior will be removed at some point from the `efiling_integration.yml` files, but for now, log and send an error email whenever it does happen to make sure that affected interviews can fix themselves. Should print enough information (everything but the type of code) for developers to address it.

Fixes #273.