### PR TITLE
Fix errors in DABuild

### DIFF
--- a/docassemble/EFSPIntegration/data/questions/admin_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/admin_interview.yml
@@ -686,6 +686,7 @@ fields:
   - Last name: updated_attorney.name.last  
     default: ${ updated_attorney.default_last }
 ---
+id: admin search dates
 question: |
   Search dates
 fields:
@@ -784,6 +785,7 @@ code: |
   resp = proxy_conn.get_user_roles(user_id)
   get_user_roles = True
 ---
+id: admin update user roles
 reconsider:
   - user_role_resp
 question: |
@@ -1296,6 +1298,7 @@ subquestion: |
 
 continue button field: show_role_resp
 ---
+id: admin show error
 event: show_error_event
 question: |
   Error

--- a/docassemble/EFSPIntegration/data/questions/any_filing_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/any_filing_interview.yml
@@ -175,6 +175,7 @@ code: |
   x.exhibits.ask_number = True
   x.exhibits.target_number = 1
 ---
+id: could not find existing case
 event: failed_case_search
 question: |
   Could not find an existing case to file into
@@ -310,6 +311,7 @@ columns:
 edit:
   - party_type
 ---
+id: who should be contacted about this filing
 sets:
   - lead_contact.name.first
 question: |
@@ -359,7 +361,7 @@ subquestion: |
   Welcome! You can make any type of filing in an ${ jurisdiction_id.title() } court, to a pre-existing or new case, in this interview.
 continue button field: welcome
 ---
-id: return date
+id: closest available return date
 question: |
   Closest available return date
 subquestion: |
@@ -421,6 +423,7 @@ code: |
     existing_case_parties = None
   load_existing_case_defaults = True
 ---
+id: alindividual adding attorney
 generic object: ALIndividual
 question: |
   Adding Attorneys for ${ x }
@@ -433,6 +436,7 @@ fields:
     code: |
       tyler_filing_attorney_options
 ---
+id: add attorney to existing parties
 question: |
   Are there any more attorneys you'd like to attach to existing contacts?
 fields:
@@ -450,6 +454,7 @@ code: |
   if is_initial_filing:
     existing_parties_new_atts.there_are_any = False
 ---
+id: add attorneys to existing users
 question: |
   Add attorneys to existing users
 fields: 

--- a/docassemble/EFSPIntegration/data/questions/codes_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/codes_interview.yml
@@ -49,6 +49,7 @@ code: |
   else:
     pass
 ---
+id: search result
 question: Search Result
 subquestion: |
   ${ [next(iter(ch.values()), "") for ch in all_choices if next(iter(ch), "") == code_choice] } with "${ search_term }"
@@ -60,6 +61,7 @@ fields:
       search_result.data
 continue button field: show_search_result
 ---
+id: retrieve result
 event: show_retrieve_result
 question: Retrieve Result
 subquestion: |
@@ -92,6 +94,7 @@ data:
       - motion_type: Motion type
       #- filing_component: Filing component
 ---
+id: choose codes 
 question: What code do you want to see?
 subquestion: |
   Only some codes can be searched:
@@ -111,6 +114,7 @@ fields:
   - Search term: search_term
     show if: do_search
 ---
+id: initial or subsequent case
 question: |
   Initial case, or subsequent case?
 subquestion: |
@@ -132,6 +136,7 @@ code: |
   case_category_choices, case_category_map = \
     choices_and_map(proxy_conn.get_case_categories(court_id).data, "{name} ({code})")
 ---
+id: case category
 question: |
   Case category?
 subquestion: |
@@ -144,6 +149,7 @@ code: |
   damage_amount_choices, damage_amount_map = \
     choices_and_map(proxy_conn.get_damage_amounts(court_id).data, "{name} ({code})")
 ---
+id: damage amount
 question: |
   Damage Amount?
 subquestion: |
@@ -156,6 +162,7 @@ code: |
   procedure_remedy_choices, procedure_remedy_map = \
     choices_and_map(proxy_conn.get_procedure_or_remedies(court_id).data, "{name} ({code})")
 ---
+id: procedure remedy
 question: |
   Procedure remedy
 subquestion: |
@@ -168,6 +175,7 @@ code: |
   case_type_choices, case_type_map = \
     choices_and_map(proxy_conn.get_case_types(court_id, case_category, timing='Initial' if is_initial_filing else 'Subsequent').data, "{name} ({code})")
 ---
+id: case type
 question: |
   Case type
 subquestion: |
@@ -180,6 +188,7 @@ code: |
   case_subtype_options, case_subtype_map = \
     choices_and_map(proxy_conn.get_case_subtypes(court_id, case_type).data, "{name} ({code})")
 ---
+id: case subtype
 question: |
   Case Subtype
 subquestion: |
@@ -194,6 +203,7 @@ code: |
   cross_reference_choices, cross_reference_map = \
     choices_and_map(proxy_conn.get_cross_references(court_id, case_category).data, "{name} ({code})")
 ---
+id: cross reference
 question: Cross References
 fields:
   - Cross references: cross_reference
@@ -203,6 +213,7 @@ code: |
   party_type_choices, party_type_map = \
     choices_and_map(proxy_conn.get_party_types(court_id, case_type).data, "{name} ({code})")
 ---
+id: party type
 question: Party type
 fields:
   - Party type: party_type
@@ -212,6 +223,7 @@ code: |
   filing_type_choices, filing_type_map = \
     choices_and_map(proxy_conn.get_filing_types(court_id, case_category, case_type, is_initial_filing).data, "{name} ({code})")
 ---
+id: filing type
 question: Filing type
 fields:
   - Filing type: filing_type
@@ -221,6 +233,7 @@ code: |
   document_type_choices, document_type_map = \
     choices_and_map(proxy_conn.get_document_types(court_id, filing_type).data, "{name} ({code})")
 ---
+id: document type
 question: Document type
 fields:
   - Document type: document_type
@@ -230,6 +243,7 @@ code: |
   optional_service_choices, optional_service_map = \
     choices_and_map(proxy_conn.get_optional_services(court_id, filing_type).data, "{name} ({code})")
 ---
+id: optional services
 question: Optional service
 fields:
   - Optional service: optional_service
@@ -239,6 +253,7 @@ code: |
   motion_type_choices, motion_type_map = \
     choices_and_map(proxy_conn.get_motion_types(court_id, filing_type).data, "{name} ({code})")
 ---
+id: motion type
 question: Motion type
 fields:
   - Motion type: motion_type
@@ -255,6 +270,7 @@ code: |
     else:
         return ""
 ---
+id: codes interview all done
 event: end
 question: All done
 subquestion: |

--- a/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
+++ b/docassemble/EFSPIntegration/data/questions/efiling_integration.yml
@@ -599,7 +599,7 @@ code: |
     del x.filing_component
     x.filing_component = x.user_chosen_filing_component
 ---
-id: document type
+id: user chosen document type
 generic object: DAObject
 question: |
   What type of document is this?

--- a/docassemble/EFSPIntegration/data/questions/login_qs.yml
+++ b/docassemble/EFSPIntegration/data/questions/login_qs.yml
@@ -28,7 +28,7 @@ question: |
   eFile${ state_name_to_code(jurisdiction_id) } Login Info
 subquestion: |
   Provide your eFile ${ jurisdiction_id.title() } Login information. If you don't yet have a login, you can create
-  <a href="${ interview_url(i=logged_out_interview, reset=1, jurisdiction_id=jurisdiction_id) }" target="_blank">a new account here</a>.
+  <a href="${ interview_url(i=logged_out_interview, reset=1, jurisdiction_id=jurisdiction_id) }" target="_blank">a new account here (opens in a new tab)</a>.
 fields:
   - email/username: my_username
   - password: my_password
@@ -188,6 +188,7 @@ if: can_check_efile and full_court_info.get("efmType", "ecf") == "ecf"
 code: |
   logged_in_user_is_admin, logged_in_user_is_global_admin = get_tyler_roles(proxy_conn, {"TYLER-ID": tyler_user_id})
 ---
+id: reset password event
 event: reset_password_screen
 question: |
   % if tyler_reset_password_resp.is_ok():

--- a/docassemble/EFSPIntegration/data/questions/logs_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/logs_interview.yml
@@ -8,7 +8,7 @@ modules:
   - .efm_client
 ---
 objects:
-  da_file: DAFile
+  - da_file: DAFile
 ---
 code: |
   proxy_conn = ProxyConnection(credentials_code_block='tyler_login')
@@ -44,14 +44,20 @@ code: |
   da_file_written = True
 ---
 mandatory: True
+code: |
+  start_screen
+  show_downloaded_logs
+---
+id: get logs from proxy
 question: Get logs from ${ proxy_conn.base_url }
 subquestion: |
   Press continue to get logs relating to your server traffic from ${ proxy_conn.base_url }.
 continue button field: start_screen
 ---
+id: show logs from proxy
 need:
   - da_file_written
-mandatory: True
+event: show_downloaded_logs
 question: Logs from ${ proxy_conn.base_url }
 subquestion: |
   Right click to download [the logs here](${ da_file.url_for() }).

--- a/docassemble/EFSPIntegration/data/questions/minimal_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/minimal_interview.yml
@@ -58,9 +58,11 @@ code: |
   else:
     cannot_efile
 ---
+id: cannot efile
 event: cannot_efile
 question: Cannot Efile
 ---
+id: minimal all done
 event: ending_screen
 question: All Done!
 ---

--- a/docassemble/EFSPIntegration/data/questions/toga_payments.yml
+++ b/docassemble/EFSPIntegration/data/questions/toga_payments.yml
@@ -243,7 +243,7 @@ reconsider:
   - global_account_id_resp
 depends on:
   - global_payment_account_id
-id: update payment method 
+id: update global payment method 
 question: |
   Update global payment method
 fields:
@@ -372,6 +372,7 @@ code: |
     log_error_and_notify(f"Wasn't able to remove payment method: {rm_payment_account_resp}")
     log(word("Wasn't able to remove payment method"), "error")
 ---
+id: confirm remove payment method
 question: Are you sure you want to remove your ${ _payment_labels(proxy_conn.get_payment_account(payment_account_id).data) }?
 subquestion: |
   You won't be able to get it back, and will have to enter all of its details again.
@@ -426,6 +427,7 @@ fields:
 ---
 reconsider:
   - tyler_payment_account_options
+id: create a payment method
 if: len(tyler_payment_account_options) == 0
 question: |
   Create a payment method

--- a/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
+++ b/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
@@ -23,7 +23,7 @@ include:
   - docassemble.AssemblyLine:assembly_line.yml
 ---
 objects:
-  person_to_reg: ALIndividual
+  - person_to_reg: ALIndividual
 ---
 variable name: account_action_list
 data: !!omap
@@ -141,7 +141,7 @@ fields:
     default: INDIVIDUAL
   - note: |
       ---
-  - Email address: person_to_reg.email
+  - "Email address (required)": person_to_reg.email
     datatype: email
     required: True
   - Phone number: person_to_reg.phone_number

--- a/docassemble/EFSPIntegration/requirements.txt
+++ b/docassemble/EFSPIntegration/requirements.txt
@@ -1,8 +1,0 @@
-docassemble.base==1.6.5
-setuptools<82.0.0
-docassemble.webapp==1.6.5
-docassemble.AssemblyLine>2.10.1
-requests>2.25.1
-types-requests
-mypy
-types-python-dateutil


### PR DESCRIPTION
Mostly adding question ids and making thinngs one mandatory block, but also added user facing text for links that open in a new tab, and a text note that email addresses are required for registration.

Also removed `requirements.txt`, as those dependencies are now present in the pyproject.toml.