### PR TITLE
Registation EFSPIntegration updates

### DIFF
--- a/docassemble/EFSPIntegration/data/questions/admin_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/admin_interview.yml
@@ -22,6 +22,10 @@ default screen parts:
 metadata:
   title: |
     EFSP Admin Interface
+  short title: |
+    EFSP Admin
+  description: |
+    Administrator-focused interface to EFSP functions
 ---
 code: |
   proxy_conn = ProxyConnection(credentials_code_block='tyler_login', default_jurisdiction=jurisdiction_id)

--- a/docassemble/EFSPIntegration/data/questions/login_qs.yml
+++ b/docassemble/EFSPIntegration/data/questions/login_qs.yml
@@ -25,23 +25,70 @@ code: |
 ---
 id: eFile Login
 question: |
-  eFile${ state_name_to_code(jurisdiction_id) } Login Info
+  Connect to your ${ efiling_system_name } account
 subquestion: |
-  Provide your eFile ${ jurisdiction_id.title() } Login information. If you don't yet have a login, you can create
-  <a href="${ interview_url(i=logged_out_interview, reset=1, jurisdiction_id=jurisdiction_id) }" target="_blank">a new account here (opens in a new tab)</a>.
+  You need to use an ${ efiling_system_name } account to e-file this document. If you don't have an account yet, we can help you make one.
+
+  ${ collapse_template(what_is_efile_template) }
+
+  % if not interview_allows_firm_account:
+  <div class="alert alert-warning" role="alert">
+    <strong>Warning</strong>: you need to use an individual filer account, not a "firm" account to file this petition. Choose "new account" if you have an existing account but it is managed by your firm.
+  </div>
+  % endif
 fields:
-  - email/username: my_username
-  - password: my_password
+  - I want to: user_login_or_make_new
+    datatype: radio
+    choices:
+      - Make a new account: new_account
+      - Login to my existing account: existing_account
+  - Email address: my_username
+    show if:
+      variable: user_login_or_make_new
+      is: existing_account
+    default: |
+      ${ showifdef("person_to_reg.email") or (user_info().email if user_logged_in() else '') }
+  - Password: my_password
     datatype: ALVisiblePassword
-    hide if: user_forgot_password
+    js show if: |
+      val("user_login_or_make_new") == "existing_account" && !val("user_forgot_password")
+    default: |
+      ${ showifdef("new_password") }
   - I forgot my password: user_forgot_password
     datatype: yesno
+    show if:
+      variable: user_login_or_make_new
+      is: existing_account
 ---
+template: what_is_efile_template
+subject: |
+  What is ${ efiling_system_name }?
+content: |
+  ${ efiling_system_name } is the Court's official system for electronically
+  filing court documents.
+
+  This website can help you securely connect to ${ efiling_system_name } using your existing ${ efiling_system_name }
+  username and password, or to make a new account.
+
+  You can manage your account from the ${ efiling_system_name } website after we help you make it
+  here.
+---
+only sets:
+  - tyler_login
 code: |
+  if user_login_or_make_new == 'new_account' and (not defined('register_status') or not register_status):
+    person_to_reg.email
+    # this code block execs twice: once to register, once to login, with different names for the
+    # login params
+    my_username = person_to_reg.email
+    my_password = new_password
+    register_status
+ 
   if showifdef('user_forgot_password'):
     tyler_reset_password_resp = proxy_conn.reset_user_password(my_username)
     reset_password_screen
-  else:
+
+  if not showifdef('user_forgot_password'):
     tyler_login_resp = proxy_conn.authenticate_user(tyler_email=my_username, tyler_password=my_password)
     del my_password
     if not tyler_login_resp.is_ok():
@@ -52,6 +99,13 @@ code: |
       login_failed_screen
     else:
       log(word("You are now connected to your e-filing account"), "primary")
+  if defined('new_password'):
+    del new_password
+  if defined('my_password'):
+    del my_password
+  if defined('tyler_register_resp'):
+    del tyler_register_resp
+  continue_stored_login = False # this is triggering when it shouldn't, maybe this is helpful?
   tyler_login = True
 ---
 need:
@@ -87,9 +141,20 @@ code: |
 ---
 id: login with redis
 continue button field: continue_stored_login
-question: Log in to eFile${ state_name_to_code(jurisdiction_id) } as ${my_username}?
+question: Log in to ${ efiling_system_name } as ${my_username}?
 subquestion: |
-  You recently logged in to eFile${ state_name_to_code(jurisdiction_id) } with the email **${ my_username }**.
+  You recently logged in to ${ efiling_system_name } with the email **${ my_username }**.
+
+  % if not interview_allows_firm_account:
+  <div class="alert alert-warning" role="alert">
+    <p>
+    <strong>Warning</strong>: you need to use an individual filer account, not a "firm" account
+    to file this petition.
+    <br/>
+    Make a new account if ${ my_username } is an account that is managed by your firm.
+    </p>
+  </div>
+  % endif
 
   Would you like to continue with this email?
 fields:
@@ -215,7 +280,7 @@ continue button field: show_activation_resp
 id: Login failed
 event: login_failed_screen
 question: |
-  eFile${ state_name_to_code(jurisdiction_id) } Login failed
+  ${ efiling_system_name } Login failed
 subquestion: |
   % if int(tyler_login_resp.response_code) == 403:
   Your login information was not correct. Go back and try again.

--- a/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
+++ b/docassemble/EFSPIntegration/data/questions/unauthenticated_actions.yml
@@ -77,6 +77,12 @@ data:
 code: |
   can_connect_to_proxy = proxy_conn.get_server_name().is_ok()
 ---
+code: |
+  efiling_system_name = f"eFile{ state_name_to_code(jurisdiction_id) }"
+---
+code: |
+  interview_allows_firm_account = True
+---
 if: can_connect_to_proxy
 id: unauth-intro
 question: |
@@ -88,22 +94,32 @@ continue button field: register_introduction
 if: can_connect_to_proxy
 id: unauth-register-done
 question: |
-  % if register_resp.is_ok():
+  % if tyler_register_resp.is_ok():
   Successfully registered
   % else:
   Something went wrong when we tried to register your account
   % endif
 subquestion: |
-  % if register_resp.is_ok():
-  You will get an email from efile${ state_name_to_code(jurisdiction_id) } asking you to activate your account.
+  % if tyler_register_resp.is_ok():
+  You will get an email from ${ efiling_system_name } asking you to activate your account.
+
+  **You will need to activate your account before proceeding further**.
 
   You can resend this activation email from the next screen.
 
   % else:
-  ${ debug_display(register_resp) }
+  ${ debug_display(tyler_register_resp) }
   % endif
-
+fields:
+  - Did you activate your email?: did_activate_email
+    datatype: yesnoradio
 continue button field: register_status
+validation code: |
+  if not did_activate_email:
+    validation_error(
+      "You must activate you account to continue.",
+      field="did_activate_email",
+    )
 ---
 id: unauth-resend-completed
 question: |
@@ -131,26 +147,37 @@ code: |
   del unauthed_user_email
   reset_user_password = True
 ---
+# if: interview_allows_firm_account
 id: registration info
+sets:
+  - person_to_reg.name.first
+  - person_to_reg.address.address
 question: |
-  Create an efile${ state_name_to_code(jurisdiction_id) } account
+  Create an ${ efiling_system_name } account
 fields:
   - Registration type: reg_type
     datatype: radio
     code: |
       account_registration_choices
     default: INDIVIDUAL
+    show if:
+      code: |
+        interview_allows_firm_account
   - note: |
       ---
+    show if:
+      code: |
+        interview_allows_firm_account
   - "Email address (required)": person_to_reg.email
     datatype: email
+    default: ${ user_info().email if user_logged_in() else ''}
     required: True
   - Phone number: person_to_reg.phone_number
     datatype: al_international_phone
-  - note: |
-      ${ password_rules.get("validationmessage") }
   - Password: new_password
     datatype: ALVisiblePassword
+    under text: |
+      ${ password_rules.get("validationmessage") }
     validate: proxy_conn.is_valid_password
   - note: |
       ---
@@ -158,11 +185,25 @@ fields:
     show if:
       variable: reg_type
       is: FIRM_ADMINISTRATOR
-  - code: person_to_reg.name_fields()
+  # Can't use name_fields() until this issue is fixed: https://github.com/SuffolkLITLab/docassemble/issues/65
+  - First: person_to_reg.name.first
+  - Middle: person_to_reg.name.middle
+    required: False
+  - Last: person_to_reg.name.last
+  - Suffix: person_to_reg.name.suffix
+    required: False
+    code: name_suffix()
   - note: |
       ---
-  - code: |
-      person_to_reg.address_fields(required={"person_to_reg.address.zip": True})
+  # Can't use address_fields() until this issue is fixed: https://github.com/SuffolkLITLab/docassemble/issues/65
+  - Address: person_to_reg.address.address
+    address autocomplete: True
+  - Unit: person_to_reg.address.unit
+    required: False
+  - City: person_to_reg.address.city
+  - State: person_to_reg.address.state
+    code: states_list()
+  - Zip: person_to_reg.address.zip
 ---
 code: |
   password_rules_resp = proxy_conn.get_password_rules()
@@ -177,8 +218,10 @@ code: |
   self_resend_activation = True
 ---
 code: |
-  register_resp = proxy_conn.register_user(person_to_reg, registration_type=reg_type, password=new_password, firm_name_or_id=showifdef('person_to_reg.firm_name', ''))
-  del new_password
+  tyler_register_resp = proxy_conn.register_user(person_to_reg, registration_type=reg_type, password=new_password, firm_name_or_id=showifdef('person_to_reg.firm_name', ''))
+  if not tyler_register_resp.is_ok():
+    log(f'Failed to register: {tyler_register_resp}')
+  # del new_password
   register = True
 ---
 id: unauth-reset-completed

--- a/docassemble/EFSPIntegration/data/questions/unauthenticated_interview.yml
+++ b/docassemble/EFSPIntegration/data/questions/unauthenticated_interview.yml
@@ -11,7 +11,7 @@ mandatory: True
 id: main-unauth-page
 event: main_unauth_page
 question: |
-  eFile${ state_name_to_code(jurisdiction_id) } User Management
+  ${ efiling_system_name } User Management
 subquestion: |
   % if can_connect_to_proxy:
   You are not logged in. Please select one of the options below.

--- a/docassemble/EFSPIntegration/interview_logic.py
+++ b/docassemble/EFSPIntegration/interview_logic.py
@@ -150,6 +150,26 @@ FieldEntry = TypedDict(
 Fields = List[FieldEntry]
 
 
+def name_fields_with_defaults(
+    proxy_conn, person: ALIndividual, is_admin: bool, can_check_efile: bool, **kwargs
+):
+    name_fields = person.name_fields(**kwargs)
+    if is_admin or not can_check_efile:
+        return name_fields
+
+    user_info = proxy_conn.get_user()
+    for data_key, field_key in [
+        ("firstName", ".first"),
+        ("middleName", ".middle"),
+        ("lastName", ".last"),
+    ]:
+        if user_info.is_ok() and data_key in user_info.data:
+            for field in name_fields:
+                if field.get("field", "").endswith(field_key):
+                    field["default"] = user_info.data.get(data_key)
+    return name_fields
+
+
 def contact_fields_with_defaults(
     proxy_conn, person: ALIndividual, is_admin: bool, can_check_efile: bool
 ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,13 @@ version = {attr = "docassemble.EFSPIntegration.__version__"}
 
 [dependency-groups]
 dev = [
-    "docassemble.base==1.9.2",
-    "docassemble.webapp==1.9.2",
+    "suffolklitlab-docassemble.base==1.9.8.post3",
+    "suffolklitlab-docassemble.webapp==1.9.8.post3",
     "types-requests",
     "types-python-dateutil",
     "mypy",
     "black",
+    "pytest"
 ]
 
 [tool.black]


### PR DESCRIPTION
* Copies the changes made in MAPetitionToSealEviction to let people register an account in the same interview that they are completing, without a new tab.
* Makes users confirm that they have activated their email when registering a new account.
* adds `name_fields_with_defaults` so users don't have to type their name twice
* uses an `efiling_system_name` to refer to the specific name of the court e-filing system, i.e. eFileMA